### PR TITLE
fix: bad request body simple in propertykey.md

### DIFF
--- a/clients/restful-api/propertykey.md
+++ b/clients/restful-api/propertykey.md
@@ -25,12 +25,9 @@ POST http://localhost:8080/graphs/hugegraph/schema/propertykeys
 
 ```json
 {
-    "property_key" : {
-        "name": "age",
-        "data_type": "INT",
-        "cardinality": "SINGLE"
-    },
-    "task_id": 0
+    "name": "age",
+    "data_type": "INT",
+    "cardinality": "SINGLE"
 }
 ```
 
@@ -69,14 +66,11 @@ PUT http://localhost:8080/graphs/hugegraph/schema/propertykeys/age?action=append
 
 ```json
 {
-    "property_key" : {
-        "name": "age",
-        "user_data": {
-            "min": 0,
-            "max": 100
-        }
-    },
-    "task_id" : 0
+    "name": "age",
+    "user_data": {
+        "min": 0,
+        "max": 100
+    }
 }
 ```
 


### PR DESCRIPTION
An error will be reported according to the original document, like:
```
Unrecognized field "property_key" (class com.baidu.hugegraph.api.schema.PropertyKeyAPI$JsonPropertyKey), not marked as ignorable (9 known properties: "check_exist", "properties", "aggregate_type", "id", "cardinality", "data_type", "name", "user_data", "write_type"])
 at [Source: (org.glassfish.jersey.message.internal.ReaderInterceptorExecutor$UnCloseableInputStream); line: 2, column: 23] (through reference chain: com.baidu.hugegraph.api.schema.PropertyKeyAPI$JsonPropertyKey["property_key"])
```

![image](https://user-images.githubusercontent.com/16890042/168087977-bf404c80-0cd9-4f17-b93e-8be06aa64197.png)

