### PR TITLE
fix: bad request body simple in propertykey.md

### DIFF
--- a/content/cn/docs/clients/restful-api/propertykey.md
+++ b/content/cn/docs/clients/restful-api/propertykey.md
@@ -31,12 +31,9 @@ POST http://localhost:8080/graphs/hugegraph/schema/propertykeys
 
 ```json
 {
-    "property_key" : {
-        "name": "age",
-        "data_type": "INT",
-        "cardinality": "SINGLE"
-    },
-    "task_id": 0
+    "name": "age",
+    "data_type": "INT",
+    "cardinality": "SINGLE"
 }
 ```
 
@@ -50,12 +47,20 @@ POST http://localhost:8080/graphs/hugegraph/schema/propertykeys
 
 ```json
 {
-    "id": 2,
-    "name": "age",
-    "data_type": "INT",
-    "cardinality": "SINGLE",
-    "properties": [],
-    "user_data": {}
+    "property_key": {
+        "id": 1,
+        "name": "age",
+        "data_type": "INT",
+        "cardinality": "SINGLE",
+        "aggregate_type": "NONE",
+        "write_type": "OLTP",
+        "properties": [],
+        "status": "CREATED",
+        "user_data": {
+            "~create_time": "2022-05-13 13:47:23.745"
+        }
+    },
+    "task_id": 0
 }
 ```
 
@@ -75,14 +80,11 @@ PUT http://localhost:8080/graphs/hugegraph/schema/propertykeys/age?action=append
 
 ```json
 {
-    "property_key" : {
-        "name": "age",
-        "user_data": {
-            "min": 0,
-            "max": 100
-        }
-    },
-    "task_id" : 0
+    "name": "age",
+    "user_data": {
+        "min": 0,
+        "max": 100
+    }
 }
 ```
 
@@ -96,15 +98,22 @@ PUT http://localhost:8080/graphs/hugegraph/schema/propertykeys/age?action=append
 
 ```json
 {
-    "id": 2,
-    "name": "age",
-    "data_type": "INT",
-    "cardinality": "SINGLE",
-    "properties": [],
-    "user_data": {
-        "min": 0,
-        "max": 100
-    }
+    "property_key": {
+        "id": 1,
+        "name": "age",
+        "data_type": "INT",
+        "cardinality": "SINGLE",
+        "aggregate_type": "NONE",
+        "write_type": "OLTP",
+        "properties": [],
+        "status": "CREATED",
+        "user_data": {
+            "min": 0,
+            "max": 100,
+            "~create_time": "2022-05-13 13:47:23.745"
+        }
+    },
+    "task_id": 0
 }
 ```
 
@@ -207,12 +216,19 @@ GET http://localhost:8080/graphs/hugegraph/schema/propertykeys/age
 
 ```json
 {
-    "id": 2,
+    "id": 1,
     "name": "age",
     "data_type": "INT",
     "cardinality": "SINGLE",
+    "aggregate_type": "NONE",
+    "write_type": "OLTP",
     "properties": [],
-    "user_data": {}
+    "status": "CREATED",
+    "user_data": {
+        "min": 0,
+        "max": 100,
+        "~create_time": "2022-05-13 13:47:23.745"
+    }
 }
 ```
 
@@ -236,14 +252,6 @@ DELETE http://localhost:8080/graphs/hugegraph/schema/propertykeys/age
 
 ```json
 {
-    "property_key" : {
-        "id": 2,
-        "name": "age",
-        "data_type": "INT",
-        "cardinality": "SINGLE",
-        "properties": [],
-        "user_data": {}
-    },
     "task_id" : 0
 }
 ```

--- a/content/en/docs/clients/restful-api/propertykey.md
+++ b/content/en/docs/clients/restful-api/propertykey.md
@@ -31,12 +31,9 @@ POST http://localhost:8080/graphs/hugegraph/schema/propertykeys
 
 ```json
 {
-    "property_key" : {
-        "name": "age",
-        "data_type": "INT",
-        "cardinality": "SINGLE"
-    },
-    "task_id": 0
+    "name": "age",
+    "data_type": "INT",
+    "cardinality": "SINGLE"
 }
 ```
 
@@ -50,12 +47,20 @@ POST http://localhost:8080/graphs/hugegraph/schema/propertykeys
 
 ```json
 {
-    "id": 2,
-    "name": "age",
-    "data_type": "INT",
-    "cardinality": "SINGLE",
-    "properties": [],
-    "user_data": {}
+    "property_key": {
+        "id": 1,
+        "name": "age",
+        "data_type": "INT",
+        "cardinality": "SINGLE",
+        "aggregate_type": "NONE",
+        "write_type": "OLTP",
+        "properties": [],
+        "status": "CREATED",
+        "user_data": {
+            "~create_time": "2022-05-13 13:47:23.745"
+        }
+    },
+    "task_id": 0
 }
 ```
 
@@ -75,14 +80,11 @@ PUT http://localhost:8080/graphs/hugegraph/schema/propertykeys/age?action=append
 
 ```json
 {
-    "property_key" : {
-        "name": "age",
-        "user_data": {
-            "min": 0,
-            "max": 100
-        }
-    },
-    "task_id" : 0
+    "name": "age",
+    "user_data": {
+        "min": 0,
+        "max": 100
+    }
 }
 ```
 
@@ -96,15 +98,22 @@ PUT http://localhost:8080/graphs/hugegraph/schema/propertykeys/age?action=append
 
 ```json
 {
-    "id": 2,
-    "name": "age",
-    "data_type": "INT",
-    "cardinality": "SINGLE",
-    "properties": [],
-    "user_data": {
-        "min": 0,
-        "max": 100
-    }
+    "property_key": {
+        "id": 1,
+        "name": "age",
+        "data_type": "INT",
+        "cardinality": "SINGLE",
+        "aggregate_type": "NONE",
+        "write_type": "OLTP",
+        "properties": [],
+        "status": "CREATED",
+        "user_data": {
+            "min": 0,
+            "max": 100,
+            "~create_time": "2022-05-13 13:47:23.745"
+        }
+    },
+    "task_id": 0
 }
 ```
 
@@ -207,12 +216,19 @@ GET http://localhost:8080/graphs/hugegraph/schema/propertykeys/age
 
 ```json
 {
-    "id": 2,
+    "id": 1,
     "name": "age",
     "data_type": "INT",
     "cardinality": "SINGLE",
+    "aggregate_type": "NONE",
+    "write_type": "OLTP",
     "properties": [],
-    "user_data": {}
+    "status": "CREATED",
+    "user_data": {
+        "min": 0,
+        "max": 100,
+        "~create_time": "2022-05-13 13:47:23.745"
+    }
 }
 ```
 
@@ -236,14 +252,6 @@ DELETE http://localhost:8080/graphs/hugegraph/schema/propertykeys/age
 
 ```json
 {
-    "property_key" : {
-        "id": 2,
-        "name": "age",
-        "data_type": "INT",
-        "cardinality": "SINGLE",
-        "properties": [],
-        "user_data": {}
-    },
     "task_id" : 0
 }
 ```


### PR DESCRIPTION
An error will be reported according to the original document, like:

`Unrecognized field "property_key" (class com.baidu.hugegraph.api.schema.PropertyKeyAPI$JsonPropertyKey), not marked as ignorable (9 known properties: "check_exist", "properties", "aggregate_type", "id", "cardinality", "data_type", "name", "user_data", "write_type"])
 at [Source: (org.glassfish.jersey.message.internal.ReaderInterceptorExecutor$UnCloseableInputStream); line: 2, column: 23] (through reference chain: com.baidu.hugegraph.api.schema.PropertyKeyAPI$JsonPropertyKey["property_key"])`

![image](https://user-images.githubusercontent.com/16890042/168087977-bf404c80-0cd9-4f17-b93e-8be06aa64197.png)

[master branch pr](https://github.com/apache/incubator-hugegraph-doc/pull/134)