### PR TITLE
chore: enable hugo action to build site automaticly

### DIFF
--- a/.github/workflows/hugo.yml
+++ b/.github/workflows/hugo.yml
@@ -15,7 +15,7 @@
 
 # Sample workflow for building and deploying a Hugo site to GitHub Pages
 # Refer: https://github.com/marketplace/actions/github-pages-action
-name: Deploy site to pages (hugo)
+name: Deploy Site (hugo)
 
 on:
   pull_request:

--- a/.github/workflows/hugo.yml
+++ b/.github/workflows/hugo.yml
@@ -27,7 +27,7 @@ on:
 
 # Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
 permissions:
-  contents: read
+  contents: write # old: read
   pages: write
   id-token: write
 
@@ -78,7 +78,7 @@ jobs:
 
       - name: Deploy
         uses: peaceiris/actions-gh-pages@v3
-        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        if: github.event_name == 'push' # && github.ref == 'refs/heads/master'
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           # https://gohugo.io/hosting-and-deployment/hosting-on-github/#github-pages-setting

--- a/.github/workflows/hugo.yml
+++ b/.github/workflows/hugo.yml
@@ -14,8 +14,7 @@
 # limitations under the License.
 
 # Sample workflow for building and deploying a Hugo site to GitHub Pages
-# Refer: https://github.com/marketplace/actions/github-pages-action
-name: Deploy Site (hugo)
+name: Deploy site to pages (hugo)
 
 on:
   pull_request:
@@ -42,13 +41,13 @@ jobs:
         uses: actions/setup-node@v2.4.0
         with:
           node-version: "16"
-
+            
       - name: Setup Hugo
         uses: peaceiris/actions-hugo@v2
         with:
           hugo-version: '0.102.3'
           extended: true
-
+          
       - uses: actions/cache@v2
         with:
           path: /tmp/hugo_cache
@@ -64,6 +63,8 @@ jobs:
         if: ${{ github.ref == 'refs/heads/master' }}
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          # https://gohugo.io/hosting-and-deployment/hosting-on-github/#github-pages-setting
+          # Refer: https://github.com/marketplace/actions/github-pages-action
           publish_dir: ./public
-          publish_branch: asf-site    # Settings > GitHub Pages set the source branch to this publish_branch
+          publish_branch: asf-site
+          keep_files: true # A simple way to keep ".asf.yaml" file
+          commit_message: ${{ github.event.head_commit.message }}

--- a/.github/workflows/hugo.yml
+++ b/.github/workflows/hugo.yml
@@ -14,39 +14,24 @@
 # limitations under the License.
 
 # Sample workflow for building and deploying a Hugo site to GitHub Pages
-name: Deploy Hugo site to Pages
+# Refer: https://github.com/marketplace/actions/github-pages-action
+name: Deploy site to pages (hugo)
 
 on:
-  # Runs on pushes targeting the default branch
   pull_request:
   push:
-    branches: ["master"]
-
-  # Allows you to run this workflow manually from the Actions tab
-  # workflow_dispatch:
-
-# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
-permissions:
-  contents: write # old: read
-  pages: write
-  id-token: write
-
-# Allow one concurrent deployment
-concurrency:
-  group: "pages"
-  cancel-in-progress: true
-
-# Default to bash
-defaults:
-  run:
-    shell: bash
+    branches: ["master"] # Set a branch name to trigger deployment
 
 jobs:
-  # Build job
-  build:
+  deploy:
     runs-on: ubuntu-latest
-    env:
-      HUGO_VERSION: 0.102.3
+    permissions:
+      contents: write
+      pages: write
+      id-token: write
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.ref }}
+    # Hugo steps
     steps:
       - uses: actions/checkout@v3
         with:
@@ -57,13 +42,13 @@ jobs:
         uses: actions/setup-node@v2.4.0
         with:
           node-version: "16"
-            
+
       - name: Setup Hugo
         uses: peaceiris/actions-hugo@v2
         with:
-          hugo-version: 'latest'
+          hugo-version: '0.102.3'
           extended: true
-          
+
       - uses: actions/cache@v2
         with:
           path: /tmp/hugo_cache
@@ -71,17 +56,14 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-hugomod-
 
-      - name: Build Site
-        env:
-          HUGO_ENV: production
+      - name: Build Site (minify)
         run: hugo --minify
 
-      - name: Deploy
+      - name: Deploy Site
         uses: peaceiris/actions-gh-pages@v3
-        if: github.event_name == 'push' # && github.ref == 'refs/heads/master'
+        if: ${{ github.ref == 'refs/heads/master' }}
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           # https://gohugo.io/hosting-and-deployment/hosting-on-github/#github-pages-setting
-          publish_branch: asf-site    # Settings > GitHub Pages set the source branch to this publish_branch
           publish_dir: ./public
-      # https://github.com/marketplace/actions/github-pages-action
+          publish_branch: asf-site    # Settings > GitHub Pages set the source branch to this publish_branch

--- a/.github/workflows/hugo.yml
+++ b/.github/workflows/hugo.yml
@@ -54,9 +54,9 @@ jobs:
           fetch-depth: 0    # Fetch all history for .GitInfo and .Lastmod
 
       - name: Setup Node
-          uses: actions/setup-node@v2.4.0
-          with:
-            node-version: "16"
+        uses: actions/setup-node@v2.4.0
+        with:
+          node-version: "16"
             
       - name: Setup Hugo
         uses: peaceiris/actions-hugo@v2

--- a/.github/workflows/hugo.yml
+++ b/.github/workflows/hugo.yml
@@ -1,0 +1,87 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Sample workflow for building and deploying a Hugo site to GitHub Pages
+name: Deploy Hugo site to Pages
+
+on:
+  # Runs on pushes targeting the default branch
+  pull_request:
+  push:
+    branches: ["master"]
+
+  # Allows you to run this workflow manually from the Actions tab
+  # workflow_dispatch:
+
+# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Allow one concurrent deployment
+concurrency:
+  group: "pages"
+  cancel-in-progress: true
+
+# Default to bash
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  # Build job
+  build:
+    runs-on: ubuntu-latest
+    env:
+      HUGO_VERSION: 0.102.3
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          submodules: true  # Fetch Hugo themes (true OR recursive)
+          fetch-depth: 0    # Fetch all history for .GitInfo and .Lastmod
+
+      - name: Setup Node
+          uses: actions/setup-node@v2.4.0
+          with:
+            node-version: "16"
+            
+      - name: Setup Hugo
+        uses: peaceiris/actions-hugo@v2
+        with:
+          hugo-version: 'latest'
+          extended: true
+          
+      - uses: actions/cache@v2
+        with:
+          path: /tmp/hugo_cache
+          key: ${{ runner.os }}-hugomod-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-hugomod-
+
+      - name: Build Site
+        env:
+          HUGO_ENV: production
+        run: hugo --minify
+
+      - name: Deploy
+        uses: peaceiris/actions-gh-pages@v3
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          # https://gohugo.io/hosting-and-deployment/hosting-on-github/#github-pages-setting
+          publish_branch: asf-site    # Settings > GitHub Pages set the source branch to this publish_branch
+          publish_dir: ./public
+      # https://github.com/marketplace/actions/github-pages-action


### PR DESCRIPTION
I read the gohugo.io's doc, and compare the Apache ShenYu deploy.yml. The confusing discussion[1] was clear. But this action could not set up to my repository, because the settings > pages could not work exactly. 

Pls review, and test.


[1] : [#147 ](https://github.com/apache/incubator-hugegraph-doc/issues/147)