### PR TITLE
doc: add hugegraph server setup guide for IDEA

### DIFF
--- a/content/cn/docs/contribution-guidelines/hugegraph-server-idea-setup.md
+++ b/content/cn/docs/contribution-guidelines/hugegraph-server-idea-setup.md
@@ -66,7 +66,7 @@ rocksdb.wal_path=.
 2023-06-05 00:43:39 [hugegraph-shutdown] [INFO] o.a.h.HugeFactory - HugeGraph is shutting down
 ```
 
-#### 3. `HugeGraphServer` 运行配置
+#### 3. 运行 `HugeGraphServer`
 
 类似地，打开 IntelliJ IDEA 的 `Run/Debug Configurations` 面板，创建一个新的 `Application` 配置，按照以下步骤进行配置：
 

--- a/content/cn/docs/contribution-guidelines/hugegraph-server-idea-setup.md
+++ b/content/cn/docs/contribution-guidelines/hugegraph-server-idea-setup.md
@@ -1,6 +1,6 @@
 ---
-title: "如何在 IDEA 中搭建 HugeGraph-Server 开发环境"
-linkTitle: "如何在 IDEA 中搭建 HugeGraph-Server 开发环境"
+title: "在 IDEA 中配置 HugeGraph-Server 开发环境"
+linkTitle: "在 IDEA 中配置 HugeGraph-Server 开发环境"
 weight: 4
 ---
 

--- a/content/cn/docs/contribution-guidelines/hugegraph-server-idea-setup.md
+++ b/content/cn/docs/contribution-guidelines/hugegraph-server-idea-setup.md
@@ -19,7 +19,6 @@ weight: 4
 
 ```bash
 git clone https://github.com/apache/hugegraph.git
-cd hugegraph
 ```
 
 ### 步骤
@@ -29,12 +28,12 @@ cd hugegraph
 为了避免配置文件的更改影响 Git 的追踪，建议将所需的配置文件拷贝到一个单独的文件夹中：
 
 ```bash
-cp -r hugegraph-dist/src/assembly/static/scripts hugegraph-dist/src/assembly/static/conf <path-to-your-directory>
+cp -r hugegraph-dist/src/assembly/static/scripts hugegraph-dist/src/assembly/static/conf path-to-your-directory
 ```
 
-#### 2. `InitStore` 运行配置
+#### 2. `InitStore` 类初始化图
 
-首先，需要在配置文件中配置数据库后端。以 RocksDB 为例，在 <path-to-your-directory>/conf/graphs/hugegraph.properties 文件中进行以下配置：
+首先，需要在配置文件中配置数据库后端。以 RocksDB 为例，在 `path-to/conf/graphs/hugegraph.properties` 文件中进行以下配置：
 
 ```properties
 backend=rocksdb
@@ -47,9 +46,9 @@ rocksdb.wal_path=.
 
 - 在 `Use classpath of module` 中选择 `hugegraph-dist`
 - 将 `Main class` 设置为 `org.apache.hugegraph.cmd.InitStore`
-- 设置运行参数为 `conf/graphs/hugegraph.properties`，这里的路径是相对于工作路径的，需要将工作路径设置为 `<path-to-your-directory>`
+- 设置运行参数为 `conf/graphs/hugegraph.properties`，这里的路径是相对于工作路径的，需要将工作路径设置为 `path-to-your-directory`
 
-配置完成后运行，如果运行成功，将会输出以下运行日志：
+配置完成后运行，如果运行成功，将会输出以下类似运行日志：
 
 ```java
 2023-06-05 00:43:37 [main] [INFO] o.a.h.u.ConfigUtil - Scanning option 'graphs' directory './conf/graphs'
@@ -87,12 +86,9 @@ rocksdb.wal_path=.
 
 ```java
 public String list(@Context GraphManager manager,
-                   @PathParam("graph") String graph,
-                   @QueryParam("label") String label,
-                   @QueryParam("properties") String properties,
-                   ......) {
-    ......
-
+                   @PathParam("graph") String graph, @QueryParam("label") String label,
+                   @QueryParam("properties") String properties, ......) {
+    // ignore log
     Map<String, Object> props = parseProperties(properties);
 ```
 
@@ -104,16 +100,16 @@ curl "http://localhost:8080/graphs/hugegraph/graph/vertices" | gunzip
 
 此时，可以在调试器中查看详细的变量信息。
 
-### 可能出现的问题
+### 可能遇到的问题
 
-#### java: package sun.misc does not exist
+*** java: package sun.misc does not exist ***
 
 原因可能是在使用 Java 11 编译时触发了交叉编译，导致项目中使用的 `sun.misc.Unsafe` 找不到符号。有两种解决方案可供选择：
 
-1. 在 IntelliJ IDEA 的 `Preferences` 中找到 `Java Compiler` 面板，然后关闭 `--release` 选项，或者
-2. 将项目的 SDK 设置为 8 (不推荐)
+1. 在 IntelliJ IDEA 的 `Preferences` 中找到 `Java Compiler` 面板，然后关闭 `--release` 选项 (推荐)
+2. 或者将项目的 SDK 版本设置为 8
 
-### 参考
+##### 参考
 
 1. [HugeGraph-Server Quick Start](/docs/quickstart/hugegraph-server/)
 2. [hugegraph-server 本地调试文档 (Win/Unix)](https://gist.github.com/imbajin/1661450f000cd62a67e46d4f1abfe82c)

--- a/content/cn/docs/contribution-guidelines/hugegraph-server-idea-setup.md
+++ b/content/cn/docs/contribution-guidelines/hugegraph-server-idea-setup.md
@@ -31,9 +31,11 @@ git clone https://github.com/apache/hugegraph.git
 cp -r hugegraph-dist/src/assembly/static/scripts hugegraph-dist/src/assembly/static/conf path-to-your-directory
 ```
 
+将 `path-to-your-directory` 替换为你创建的文件夹的路径。
+
 #### 2. `InitStore` 类初始化图
 
-首先，需要在配置文件中配置数据库后端。以 RocksDB 为例，在 `path-to/conf/graphs/hugegraph.properties` 文件中进行以下配置：
+首先，需要在配置文件中配置数据库后端。以 RocksDB 为例，在 `path-to-your-directory/conf/graphs/hugegraph.properties` 文件中进行以下配置：
 
 ```properties
 backend=rocksdb
@@ -70,9 +72,9 @@ rocksdb.wal_path=.
 
 - 在 `Use classpath of module` 中选择 `hugegraph-dist`
 - 将 `Main class` 设置为 `org.apache.hugegraph.dist.HugeGraphServer`
-- 设置运行参数为 `conf/gremlin-server.yaml conf/rest-server.properties`，同样地，这里的路径是相对于工作路径的，需要将工作路径设置为 `<path-to-your-directory>`
+- 设置运行参数为 `conf/gremlin-server.yaml conf/rest-server.properties`，同样地，这里的路径是相对于工作路径的，需要将工作路径设置为 `path-to-your-directory`
 
-配置完成后运行，如果看到以下日志，表示 `HugeGraphServer` 已经成功启动：
+配置完成后运行，如果看到以下类似日志，表示 `HugeGraphServer` 已经成功启动：
 
 ```java
 ......
@@ -106,7 +108,7 @@ curl "http://localhost:8080/graphs/hugegraph/graph/vertices" | gunzip
 
 原因可能是在使用 Java 11 编译时触发了交叉编译，导致项目中使用的 `sun.misc.Unsafe` 找不到符号。有两种解决方案可供选择：
 
-1. 在 IntelliJ IDEA 的 `Preferences` 中找到 `Java Compiler` 面板，然后关闭 `--release` 选项 (推荐)
+1. 在 IntelliJ IDEA 的 `Preferences/Settings` 中找到 `Java Compiler` 面板，然后关闭 `--release` 选项 (推荐)
 2. 或者将项目的 SDK 版本设置为 8
 
 ##### 参考

--- a/content/cn/docs/contribution-guidelines/hugegraph-server-idea-setup.md
+++ b/content/cn/docs/contribution-guidelines/hugegraph-server-idea-setup.md
@@ -1,0 +1,141 @@
+---
+title: "如何在 IDEA 中搭建 HugeGraph-Server 开发环境"
+linkTitle: "如何在 IDEA 中搭建 HugeGraph-Server 开发环境"
+weight: 4
+---
+
+> 注意：下述配置仅供参考，基于[这个版本](https://github.com/apache/incubator-hugegraph/commit/a946ad1de4e8f922251a5241ffc957c33379677f)，在 Linux 和 macOS 平台下进行了测试。
+
+### 背景
+
+在 [Quick Start](/docs/quickstart/hugegraph-server/) 部分中已经给出了使用脚本启停 HugeGraphServer 的流程，但是对于开发者而言，这种方式没有与 IDE 工具集成，使用脚本会较为繁琐，调试起来也比较麻烦。下面以 Linux 平台为例，介绍使用 IntelliJ IDEA 运行与调试 HugeGraph-Server 的流程。
+
+本地启动的核心与**脚本启动**是一样的：
+
+1. 初始化数据库后端, 执行 `InitStore` 类初始化图
+2. 启动 HugeGraphServer，执行 `HugeGraphServer` 类加载初始化的图信息启动
+
+在进行下述流程前，请确保已经 clone 了 HugeGraph 的源代码，并且已经配置了 JDK 11 等开发环境。
+
+```
+git clone https://github.com/apache/hugegraph.git
+cd hugegraph
+```
+
+### 步骤
+
+#### 1. 配置文件拷贝
+
+为了避免配置文件的变动影响 Git 的追踪，建议将所需的配置文件拷贝到一个单独的文件夹中：
+
+```
+cp -r hugegraph-dist/src/assembly/static/scripts hugegraph-dist/src/assembly/static/conf <path-to-your-directory>
+```
+
+#### 2. `InitStore` 运行配置
+
+首先，需要在拷贝的文件中配置数据库后端，这里以 RocksDB 为例，打开 `<path-to-your-directory>/conf/graphs/hugegraph.properties`，配置如下：
+
+```
+backend=rocksdb
+serializer=binary
+rocksdb.data_path=.
+rocksdb.wal_path=.
+```
+
+然后，打开 IDEA 的 `Run/Debug configurations` 面板，新建一个 `Application`，进行如下配置：
+
+- 选中 `Use classpath of module`  为 `hugegraph-dist`
+- 设置 `Main class` 为 `org.apache.hugegraph.cmd.InitStore` 类
+- 设置运行参数为 `conf/graphs/hugegraph.properties`，这里的路径是相对于工作路径的，需要设置工作路径为 `<path-to-your-directory>`
+
+配置完成后运行，如果运行成功，会打印下述运行日志：
+
+```
+2023-06-05 00:43:37 [main] [INFO] o.a.h.u.ConfigUtil - Scanning option 'graphs' directory './conf/graphs'
+2023-06-05 00:43:37 [main] [INFO] o.a.h.c.InitStore - Init graph with config file: ./conf/graphs/hugegraph.properties
+2023-06-05 00:43:38 [db-open-1] [INFO] o.a.h.b.s.r.RocksDBStore - Opening RocksDB with data path: ./m
+2023-06-05 00:43:38 [db-open-1] [INFO] o.a.h.b.s.r.RocksDBStore - Failed to open RocksDB './m' with database 'hugegraph', try to init CF later
+2023-06-05 00:43:38 [main] [INFO] o.a.h.b.c.CacheManager - Init RamCache for 'schema-id-hugegraph' with capacity 10000
+2023-06-05 00:43:38 [main] [INFO] o.a.h.b.c.CacheManager - Init RamCache for 'schema-name-hugegraph' with capacity 10000
+2023-06-05 00:43:38 [db-open-1] [INFO] o.a.h.b.s.r.RocksDBStore - Opening RocksDB with data path: ./s
+main dict load finished, time elapsed 697 ms
+model load finished, time elapsed 64 ms.
+2023-06-05 00:43:39 [db-open-1] [INFO] o.a.h.b.s.r.RocksDBStore - Opening RocksDB with data path: ./g
+2023-06-05 00:43:39 [main] [INFO] o.c.o.l.Uns - OHC using JNA OS native malloc/free
+2023-06-05 00:43:39 [main] [INFO] o.a.h.b.c.CacheManager - Init LevelCache for 'vertex-hugegraph' with capacity 10000:10000000
+2023-06-05 00:43:39 [main] [INFO] o.a.h.b.c.CacheManager - Init LevelCache for 'edge-hugegraph' with capacity 1000:1000000
+2023-06-05 00:43:39 [main] [INFO] o.a.h.b.c.CacheManager - Init RamCache for 'users-hugegraph' with capacity 10240
+2023-06-05 00:43:39 [main] [INFO] o.a.h.b.c.CacheManager - Init RamCache for 'users_pwd-hugegraph' with capacity 10240
+2023-06-05 00:43:39 [main] [INFO] o.a.h.b.c.CacheManager - Init RamCache for 'token-hugegraph' with capacity 10240
+2023-06-05 00:43:39 [main] [INFO] o.a.h.b.s.r.RocksDBStore - Write down the backend version: 1.11
+2023-06-05 00:43:39 [main] [INFO] o.a.h.StandardHugeGraph - Graph 'hugegraph' has been initialized
+2023-06-05 00:43:39 [main] [INFO] o.a.h.StandardHugeGraph - Close graph standardhugegraph[hugegraph]
+2023-06-05 00:43:39 [db-open-1] [INFO] o.a.h.b.s.r.RocksDBStore - Opening RocksDB with data path: ./m
+2023-06-05 00:43:39 [db-open-1] [INFO] o.a.h.b.s.r.RocksDBStore - Opening RocksDB with data path: ./s
+2023-06-05 00:43:39 [db-open-1] [INFO] o.a.h.b.s.r.RocksDBStore - Opening RocksDB with data path: ./g
+2023-06-05 00:43:39 [main] [INFO] o.a.h.HugeFactory - HugeFactory shutdown
+2023-06-05 00:43:39 [hugegraph-shutdown] [INFO] o.a.h.HugeFactory - HugeGraph is shutting down
+```
+
+#### 3. `HugeGraphServer` 运行配置
+
+类似的，打开 IDEA 的 `Run/Debug configurations` 面板，新建一个 `Application`，进行如下配置：
+
+- 选中 `Use classpath of module`  为 `hugegraph-dist`
+- 设置 `Main class` 为 `org.apache.hugegraph.dist.HugeGraphServer` 类
+- 设置运行参数为 `conf/gremlin-server.yaml conf/rest-server.properties`，同样的，这里的路径是相对于工作路径的，需要设置工作路径为 `<path-to-your-directory>`
+
+配置完成后运行，如果看到下述日志，代表 `HugeGraphServer` 已经成功启动：
+
+```
+......
+2023-06-05 00:51:56 [gremlin-server-boss-1] [INFO] o.a.t.g.s.GremlinServer - Gremlin Server configured with worker thread pool of 1, gremlin pool of 8 and boss thread pool of 1.
+2023-06-05 00:51:56 [gremlin-server-boss-1] [INFO] o.a.t.g.s.GremlinServer - Channel started at port 8182.
+```
+
+#### 4. 调试 `HugeGraphServer`
+
+在完成上述配置后，可以尝试对 `HugeGraphServer` 进行调试，使用调试模式运行 `HugeGraphServer` 后，在下述对应的[位置](https://github.com/apache/hugegraph/blob/a946ad1de4e8f922251a5241ffc957c33379677f/hugegraph-api/src/main/java/org/apache/hugegraph/api/graph/VertexAPI.java#L238)打断点：
+
+```java
+@GET
+@Timed
+@Compress
+@Produces(APPLICATION_JSON_WITH_CHARSET)
+@RolesAllowed({"admin", "$owner=$graph $action=vertex_read"})
+public String list(@Context GraphManager manager,
+                   @PathParam("graph") String graph,
+                   @QueryParam("label") String label,
+                   @QueryParam("properties") String properties,
+                   @QueryParam("keep_start_p")
+                   @DefaultValue("false") boolean keepStartP,
+                   @QueryParam("offset") @DefaultValue("0") long offset,
+                   @QueryParam("page") String page,
+                   @QueryParam("limit") @DefaultValue("100") long limit) {
+    LOG.debug("Graph [{}] query vertices by label: {}, properties: {}, " +
+              "offset: {}, page: {}, limit: {}",
+              graph, label, properties, offset, page, limit);
+    Map<String, Object> props = parseProperties(properties);
+```
+然后使用 RESTful API 请求 `HugeGraphServer`
+```
+curl "http://localhost:8080/graphs/hugegraph/graph/vertices" | gunzip
+```
+此时可以在 Debugger 中查看详细的变量信息。
+
+### 可能出现的问题
+
+#### java: package sun.misc does not exist
+
+原因可能因为使用 Java 11 编译时触发了交叉编译，导致项目中使用的 `sun.misc.Unsafe` 找不到符号，有两种解决方案：
+
+1. 设置 Project SDK 为 8，或者
+2. 在 IDEA 的 `Preference` 中找到 `Java Compiler` 面板，然后关闭 `--release` 选项
+
+### 参考
+
+1. [HugeGraph-Server Quick Start](/docs/quickstart/hugegraph-server/)
+2. [hugegraph-server 本地调试文档 (Win/Unix)](https://gist.github.com/imbajin/1661450f000cd62a67e46d4f1abfe82c)
+3. ["package sun.misc does not exist" compilation error](https://youtrack.jetbrains.com/issue/IDEA-180033)
+4. [Cannot compile: java: package sun.misc does not exist](https://youtrack.jetbrains.com/issue/IDEA-201168)

--- a/content/cn/docs/contribution-guidelines/hugegraph-server-idea-setup.md
+++ b/content/cn/docs/contribution-guidelines/hugegraph-server-idea-setup.md
@@ -8,16 +8,16 @@ weight: 4
 
 ### 背景
 
-在 [Quick Start](/docs/quickstart/hugegraph-server/) 部分中已经给出了使用脚本启停 HugeGraphServer 的流程，但是对于开发者而言，这种方式没有与 IDE 工具集成，使用脚本会较为繁琐，调试起来也比较麻烦。下面以 Linux 平台为例，介绍使用 IntelliJ IDEA 运行与调试 HugeGraph-Server 的流程。
+在 [Quick Start](/docs/quickstart/hugegraph-server/) 部分已经介绍了使用**脚本**启停 HugeGraphServer 的流程。下面以 Linux 平台为例，介绍使用 **IntelliJ IDEA** 运行与调试 HugeGraph-Server 的流程。
 
 本地启动的核心与**脚本启动**是一样的：
 
-1. 初始化数据库后端, 执行 `InitStore` 类初始化图
+1. 初始化数据库后端，执行 `InitStore` 类初始化图
 2. 启动 HugeGraphServer，执行 `HugeGraphServer` 类加载初始化的图信息启动
 
-在进行下述流程前，请确保已经 clone 了 HugeGraph 的源代码，并且已经配置了 JDK 11 等开发环境。
+在执行下述流程之前，请确保已经克隆了 HugeGraph 的源代码，并且已经配置了 JDK 11 等开发环境。
 
-```
+```bash
 git clone https://github.com/apache/hugegraph.git
 cd hugegraph
 ```
@@ -26,48 +26,35 @@ cd hugegraph
 
 #### 1. 配置文件拷贝
 
-为了避免配置文件的变动影响 Git 的追踪，建议将所需的配置文件拷贝到一个单独的文件夹中：
+为了避免配置文件的更改影响 Git 的追踪，建议将所需的配置文件拷贝到一个单独的文件夹中：
 
-```
+```bash
 cp -r hugegraph-dist/src/assembly/static/scripts hugegraph-dist/src/assembly/static/conf <path-to-your-directory>
 ```
 
 #### 2. `InitStore` 运行配置
 
-首先，需要在拷贝的文件中配置数据库后端，这里以 RocksDB 为例，打开 `<path-to-your-directory>/conf/graphs/hugegraph.properties`，配置如下：
+首先，需要在配置文件中配置数据库后端。以 RocksDB 为例，在 <path-to-your-directory>/conf/graphs/hugegraph.properties 文件中进行以下配置：
 
-```
+```properties
 backend=rocksdb
 serializer=binary
 rocksdb.data_path=.
 rocksdb.wal_path=.
 ```
 
-然后，打开 IDEA 的 `Run/Debug configurations` 面板，新建一个 `Application`，进行如下配置：
+然后，打开 IntelliJ IDEA 的 `Run/Debug Configurations` 面板，创建一个新的 Application 配置，按照以下步骤进行配置：
 
-- 选中 `Use classpath of module`  为 `hugegraph-dist`
-- 设置 `Main class` 为 `org.apache.hugegraph.cmd.InitStore` 类
-- 设置运行参数为 `conf/graphs/hugegraph.properties`，这里的路径是相对于工作路径的，需要设置工作路径为 `<path-to-your-directory>`
+- 在 `Use classpath of module` 中选择 `hugegraph-dist`
+- 将 `Main class` 设置为 `org.apache.hugegraph.cmd.InitStore`
+- 设置运行参数为 `conf/graphs/hugegraph.properties`，这里的路径是相对于工作路径的，需要将工作路径设置为 `<path-to-your-directory>`
 
-配置完成后运行，如果运行成功，会打印下述运行日志：
+配置完成后运行，如果运行成功，将会输出以下运行日志：
 
-```
+```java
 2023-06-05 00:43:37 [main] [INFO] o.a.h.u.ConfigUtil - Scanning option 'graphs' directory './conf/graphs'
 2023-06-05 00:43:37 [main] [INFO] o.a.h.c.InitStore - Init graph with config file: ./conf/graphs/hugegraph.properties
-2023-06-05 00:43:38 [db-open-1] [INFO] o.a.h.b.s.r.RocksDBStore - Opening RocksDB with data path: ./m
-2023-06-05 00:43:38 [db-open-1] [INFO] o.a.h.b.s.r.RocksDBStore - Failed to open RocksDB './m' with database 'hugegraph', try to init CF later
-2023-06-05 00:43:38 [main] [INFO] o.a.h.b.c.CacheManager - Init RamCache for 'schema-id-hugegraph' with capacity 10000
-2023-06-05 00:43:38 [main] [INFO] o.a.h.b.c.CacheManager - Init RamCache for 'schema-name-hugegraph' with capacity 10000
-2023-06-05 00:43:38 [db-open-1] [INFO] o.a.h.b.s.r.RocksDBStore - Opening RocksDB with data path: ./s
-main dict load finished, time elapsed 697 ms
-model load finished, time elapsed 64 ms.
-2023-06-05 00:43:39 [db-open-1] [INFO] o.a.h.b.s.r.RocksDBStore - Opening RocksDB with data path: ./g
-2023-06-05 00:43:39 [main] [INFO] o.c.o.l.Uns - OHC using JNA OS native malloc/free
-2023-06-05 00:43:39 [main] [INFO] o.a.h.b.c.CacheManager - Init LevelCache for 'vertex-hugegraph' with capacity 10000:10000000
-2023-06-05 00:43:39 [main] [INFO] o.a.h.b.c.CacheManager - Init LevelCache for 'edge-hugegraph' with capacity 1000:1000000
-2023-06-05 00:43:39 [main] [INFO] o.a.h.b.c.CacheManager - Init RamCache for 'users-hugegraph' with capacity 10240
-2023-06-05 00:43:39 [main] [INFO] o.a.h.b.c.CacheManager - Init RamCache for 'users_pwd-hugegraph' with capacity 10240
-2023-06-05 00:43:39 [main] [INFO] o.a.h.b.c.CacheManager - Init RamCache for 'token-hugegraph' with capacity 10240
+......
 2023-06-05 00:43:39 [main] [INFO] o.a.h.b.s.r.RocksDBStore - Write down the backend version: 1.11
 2023-06-05 00:43:39 [main] [INFO] o.a.h.StandardHugeGraph - Graph 'hugegraph' has been initialized
 2023-06-05 00:43:39 [main] [INFO] o.a.h.StandardHugeGraph - Close graph standardhugegraph[hugegraph]
@@ -80,58 +67,51 @@ model load finished, time elapsed 64 ms.
 
 #### 3. `HugeGraphServer` 运行配置
 
-类似的，打开 IDEA 的 `Run/Debug configurations` 面板，新建一个 `Application`，进行如下配置：
+类似地，打开 IntelliJ IDEA 的 `Run/Debug Configurations` 面板，创建一个新的 `Application` 配置，按照以下步骤进行配置：
 
-- 选中 `Use classpath of module`  为 `hugegraph-dist`
-- 设置 `Main class` 为 `org.apache.hugegraph.dist.HugeGraphServer` 类
-- 设置运行参数为 `conf/gremlin-server.yaml conf/rest-server.properties`，同样的，这里的路径是相对于工作路径的，需要设置工作路径为 `<path-to-your-directory>`
+- 在 `Use classpath of module` 中选择 `hugegraph-dist`
+- 将 `Main class` 设置为 `org.apache.hugegraph.dist.HugeGraphServer`
+- 设置运行参数为 `conf/gremlin-server.yaml conf/rest-server.properties`，同样地，这里的路径是相对于工作路径的，需要将工作路径设置为 `<path-to-your-directory>`
 
-配置完成后运行，如果看到下述日志，代表 `HugeGraphServer` 已经成功启动：
+配置完成后运行，如果看到以下日志，表示 `HugeGraphServer` 已经成功启动：
 
-```
+```java
 ......
 2023-06-05 00:51:56 [gremlin-server-boss-1] [INFO] o.a.t.g.s.GremlinServer - Gremlin Server configured with worker thread pool of 1, gremlin pool of 8 and boss thread pool of 1.
 2023-06-05 00:51:56 [gremlin-server-boss-1] [INFO] o.a.t.g.s.GremlinServer - Channel started at port 8182.
 ```
 
-#### 4. 调试 `HugeGraphServer`
+#### 4. 调试 `HugeGraphServer` (可选)
 
-在完成上述配置后，可以尝试对 `HugeGraphServer` 进行调试，使用调试模式运行 `HugeGraphServer` 后，在下述对应的[位置](https://github.com/apache/hugegraph/blob/a946ad1de4e8f922251a5241ffc957c33379677f/hugegraph-api/src/main/java/org/apache/hugegraph/api/graph/VertexAPI.java#L238)打断点：
+在完成上述配置后，可以尝试对 `HugeGraphServer` 进行调试。在调试模式下运行 `HugeGraphServer`，并在以下[位置](https://github.com/apache/hugegraph/blob/a946ad1de4e8f922251a5241ffc957c33379677f/hugegraph-api/src/main/java/org/apache/hugegraph/api/graph/VertexAPI.java#L238)设置断点：
 
 ```java
-@GET
-@Timed
-@Compress
-@Produces(APPLICATION_JSON_WITH_CHARSET)
-@RolesAllowed({"admin", "$owner=$graph $action=vertex_read"})
 public String list(@Context GraphManager manager,
                    @PathParam("graph") String graph,
                    @QueryParam("label") String label,
                    @QueryParam("properties") String properties,
-                   @QueryParam("keep_start_p")
-                   @DefaultValue("false") boolean keepStartP,
-                   @QueryParam("offset") @DefaultValue("0") long offset,
-                   @QueryParam("page") String page,
-                   @QueryParam("limit") @DefaultValue("100") long limit) {
-    LOG.debug("Graph [{}] query vertices by label: {}, properties: {}, " +
-              "offset: {}, page: {}, limit: {}",
-              graph, label, properties, offset, page, limit);
+                   ......) {
+    ......
+
     Map<String, Object> props = parseProperties(properties);
 ```
-然后使用 RESTful API 请求 `HugeGraphServer`
-```
+
+然后，使用 RESTful API 请求 `HugeGraphServer`：
+
+```bash
 curl "http://localhost:8080/graphs/hugegraph/graph/vertices" | gunzip
 ```
-此时可以在 Debugger 中查看详细的变量信息。
+
+此时，可以在调试器中查看详细的变量信息。
 
 ### 可能出现的问题
 
 #### java: package sun.misc does not exist
 
-原因可能因为使用 Java 11 编译时触发了交叉编译，导致项目中使用的 `sun.misc.Unsafe` 找不到符号，有两种解决方案：
+原因可能是在使用 Java 11 编译时触发了交叉编译，导致项目中使用的 `sun.misc.Unsafe` 找不到符号。有两种解决方案可供选择：
 
-1. 设置 Project SDK 为 8，或者
-2. 在 IDEA 的 `Preference` 中找到 `Java Compiler` 面板，然后关闭 `--release` 选项
+1. 在 IntelliJ IDEA 的 `Preferences` 中找到 `Java Compiler` 面板，然后关闭 `--release` 选项，或者
+2. 将项目的 SDK 设置为 8 (不推荐)
 
 ### 参考
 

--- a/content/cn/docs/quickstart/hugegraph-server.md
+++ b/content/cn/docs/quickstart/hugegraph-server.md
@@ -428,3 +428,7 @@ _说明_
 $cd hugegraph-${version}
 $bin/stop-hugegraph.sh
 ```
+
+### 8 使用 IntelliJ IDEA 调试 Server
+
+请参考[如何在 IDEA 中搭建 HugeGraph-Server 开发环境](/docs/contribution-guidelines/hugegraph-server-idea-setup)

--- a/content/en/docs/contribution-guidelines/hugegraph-server-idea-setup.md
+++ b/content/en/docs/contribution-guidelines/hugegraph-server-idea-setup.md
@@ -4,20 +4,20 @@ linkTitle: "How to Set Up HugeGraph-Server Development Environment in IDEA"
 weight: 4
 ---
 
-> Note: The following configuration is for reference purposes only, and has been tested on Linux and macOS platforms based on [this version](https://github.com/apache/incubator-hugegraph/commit/a946ad1de4e8f922251a5241ffc957c33379677f).
+> NOTE: The following configuration is for reference purposes only, and has been tested on Linux and macOS platforms based on [this version](https://github.com/apache/incubator-hugegraph/commit/a946ad1de4e8f922251a5241ffc957c33379677f).
 
 ### Background
 
-The [Quick Start](/docs/quickstart/hugegraph-server/) section provides instructions on how to start and stop HugeGraphServer using scripts. However, for developers, this method may not be convenient as it is not integrated with IDE tools and can be difficult to debug. In this guide, we will explain how to run and debug HugeGraph-Server on the Linux platform using IntelliJ IDEA.
+The [Quick Start](/docs/quickstart/hugegraph-server/) section provides instructions on how to start and stop HugeGraphServer using **scripts**. In this guide, we will explain how to run and debug HugeGraph-Server on the Linux platform using **IntelliJ IDEA**.
 
-The process of local startup is similar to **script startup** and involves the following steps:
+The core steps for local startup are the same as starting with **scripts**:
 
 1. Initialize the database backend by executing the `InitStore` class to initialize the graph.
 2. Start HugeGraphServer by executing the `HugeGraphServer` class to load the initialized graph information and start the server.
 
 Before proceeding with the following process, make sure that you have cloned the source code of HugeGraph and have configured the development environment, such as JDK 11.
 
-```
+```bash
 git clone https://github.com/apache/hugegraph.git
 cd hugegraph
 ```
@@ -28,7 +28,7 @@ cd hugegraph
 
 To avoid the impact of configuration file changes on Git tracking, it is recommended to copy the required configuration files to a separate folder. Run the following command to copy the files:
 
-```
+```bash
 cp -r hugegraph-dist/src/assembly/static/scripts hugegraph-dist/src/assembly/static/conf <path-to-your-directory>
 ```
 
@@ -36,40 +36,27 @@ Replace `<path-to-your-directory>` with the path to the directory where you want
 
 #### 2. Configure `InitStore`
 
-Next, you need to configure the database backend in the copied files. In this example, we will use RocksDB. Open `<path-to-your-directory>/conf/graphs/hugegraph.properties` and configure it as follows:
+First, you need to configure the database backend in the configuration files. In this example, we will use RocksDB. Open `<path-to-your-directory>/conf/graphs/hugegraph.properties` and configure it as follows:
 
-```
+```properties
 backend=rocksdb
 serializer=binary
 rocksdb.data_path=.
 rocksdb.wal_path=.
 ```
 
-Then, open the `Run/Debug configurations` panel of IDEA and create a new `Application` with the following configurations:
+Next, open the `Run/Debug Configurations` panel in IntelliJ IDEA and create a new Application configuration. Follow these steps for the configuration:
 
-- Select `Use classpath of module` as `hugegraph-dist`
-- Set `Main class` to `org.apache.hugegraph.cmd.InitStore`
-- Set the running parameter to `conf/graphs/hugegraph.properties`. The path here is relative to the working directory, so you need to set the working directory to `<path-to-your-directory>`
+- Select `hugegraph-dist` as the `Use classpath of module`.
+- Set the `Main class` to `org.apache.hugegraph.cmd.InitStore`.
+- Set the program arguments to `conf/graphs/hugegraph.properties`. Note that the path here is relative to the working directory, so make sure to set the working directory to `<path-to-your-directory>`.
 
-After the configuration is complete, run it. If the operation is successful, the following running log will be printed:
+Once the configuration is completed, run it. If the execution is successful, the following runtime logs will be displayed:
 
-```
+```java
 2023-06-05 00:43:37 [main] [INFO] o.a.h.u.ConfigUtil - Scanning option 'graphs' directory './conf/graphs'
 2023-06-05 00:43:37 [main] [INFO] o.a.h.c.InitStore - Init graph with config file: ./conf/graphs/hugegraph.properties
-2023-06-05 00:43:38 [db-open-1] [INFO] o.a.h.b.s.r.RocksDBStore - Opening RocksDB with data path: ./m
-2023-06-05 00:43:38 [db-open-1] [INFO] o.a.h.b.s.r.RocksDBStore - Failed to open RocksDB './m' with database 'hugegraph', try to init CF later
-2023-06-05 00:43:38 [main] [INFO] o.a.h.b.c.CacheManager - Init RamCache for 'schema-id-hugegraph' with capacity 10000
-2023-06-05 00:43:38 [main] [INFO] o.a.h.b.c.CacheManager - Init RamCache for 'schema-name-hugegraph' with capacity 10000
-2023-06-05 00:43:38 [db-open-1] [INFO] o.a.h.b.s.r.RocksDBStore - Opening RocksDB with data path: ./s
-main dict load finished, time elapsed 697 ms
-model load finished, time elapsed 64 ms.
-2023-06-05 00:43:39 [db-open-1] [INFO] o.a.h.b.s.r.RocksDBStore - Opening RocksDB with data path: ./g
-2023-06-05 00:43:39 [main] [INFO] o.c.o.l.Uns - OHC using JNA OS native malloc/free
-2023-06-05 00:43:39 [main] [INFO] o.a.h.b.c.CacheManager - Init LevelCache for 'vertex-hugegraph' with capacity 10000:10000000
-2023-06-05 00:43:39 [main] [INFO] o.a.h.b.c.CacheManager - Init LevelCache for 'edge-hugegraph' with capacity 1000:1000000
-2023-06-05 00:43:39 [main] [INFO] o.a.h.b.c.CacheManager - Init RamCache for 'users-hugegraph' with capacity 10240
-2023-06-05 00:43:39 [main] [INFO] o.a.h.b.c.CacheManager - Init RamCache for 'users_pwd-hugegraph' with capacity 10240
-2023-06-05 00:43:39 [main] [INFO] o.a.h.b.c.CacheManager - Init RamCache for 'token-hugegraph' with capacity 10240
+......
 2023-06-05 00:43:39 [main] [INFO] o.a.h.b.s.r.RocksDBStore - Write down the backend version: 1.11
 2023-06-05 00:43:39 [main] [INFO] o.a.h.StandardHugeGraph - Graph 'hugegraph' has been initialized
 2023-06-05 00:43:39 [main] [INFO] o.a.h.StandardHugeGraph - Close graph standardhugegraph[hugegraph]
@@ -82,58 +69,51 @@ model load finished, time elapsed 64 ms.
 
 #### 3. Configure `HugeGraphServer`
 
-Similarly, open the `Run/Debug configurations` panel of IDEA and create a new `Application` with the following configurations:
+Similarly, open the `Run/Debug Configurations` panel in IntelliJ IDEA and create a new `Application` configuration. Follow these steps for the configuration:
 
-- Select `Use classpath of module` as `hugegraph-dist`
-- Set `Main class` to `org.apache.hugegraph.dist.HugeGraphServer`
-- Set the running parameter to `conf/gremlin-server.yaml conf/rest-server.properties`. Similarly, the path here is relative to the working directory, so you need to set the working directory to `<path-to-your-directory>`
+- Select `hugegraph-dist` as the `Use classpath of module`.
+- Set the `Main class` to `org.apache.hugegraph.dist.HugeGraphServer`.
+- Set the program arguments to `conf/gremlin-server.yaml conf/rest-server.properties`. Similarly, note that the path here is relative to the working directory, so make sure to set the working directory to `<path-to-your-directory>`.
 
-After the configuration is complete, run it. If you see the following log, it means that `HugeGraphServer` has been successfully started:
+Once the configuration is completed, run it. If you see the following logs, it means that `HugeGraphServer` has been successfully started:
 
-```
+```java
 ......
 2023-06-05 00:51:56 [gremlin-server-boss-1] [INFO] o.a.t.g.s.GremlinServer - Gremlin Server configured with worker thread pool of 1, gremlin pool of 8 and boss thread pool of 1.
 2023-06-05 00:51:56 [gremlin-server-boss-1] [INFO] o.a.t.g.s.GremlinServer - Channel started at port 8182.
 ```
 
-#### 4. Debugging `HugeGraphServer`
+#### 4. Debugging `HugeGraphServer` (optional)
 
-After completing the above configuration, you can try to debug `HugeGraphServer`. Run `HugeGraphServer` in debug mode, and set breakpoints at the corresponding [location](https://github.com/apache/hugegraph/blob/a946ad1de4e8f922251a5241ffc957c33379677f/hugegraph-api/src/main/java/org/apache/hugegraph/api/graph/VertexAPI.java#L238):
+After completing the above configuration, you can try debugging `HugeGraphServer`. Run `HugeGraphServer` in debug mode and set a breakpoint at the following [location](https://github.com/apache/hugegraph/blob/a946ad1de4e8f922251a5241ffc957c33379677f/hugegraph-api/src/main/java/org/apache/hugegraph/api/graph/VertexAPI.java#L238):
 
 ```java
-@GET
-@Timed
-@Compress
-@Produces(APPLICATION_JSON_WITH_CHARSET)
-@RolesAllowed({"admin", "$owner=$graph $action=vertex_read"})
 public String list(@Context GraphManager manager,
                    @PathParam("graph") String graph,
                    @QueryParam("label") String label,
                    @QueryParam("properties") String properties,
-                   @QueryParam("keep_start_p")
-                   @DefaultValue("false") boolean keepStartP,
-                   @QueryParam("offset") @DefaultValue("0") long offset,
-                   @QueryParam("page") String page,
-                   @QueryParam("limit") @DefaultValue("100") long limit) {
-    LOG.debug("Graph [{}] query vertices by label: {}, properties: {}, " +
-              "offset: {}, page: {}, limit: {}",
-              graph, label, properties, offset, page, limit);
+                   ......) {
+    ......
+
     Map<String, Object> props = parseProperties(properties);
 ```
+
 Then use the RESTful API to request `HugeGraphServer`:
-```
+
+```bash
 curl "http://localhost:8080/graphs/hugegraph/graph/vertices" | gunzip
 ```
-At this point, you can view detailed variable information in the Debugger.
+
+At this point, you can view detailed variable information in the debugger.
 
 ### Possible Issues
 
 #### java: package sun.misc does not exist
 
-The reason may be that cross-compilation is triggered when using Java 11 to compile, causing the symbol of `sun.misc.Unsafe` used in the project to not be found. There are two solutions:
+The reason may be that cross-compilation is triggered when using Java 11 to compile, causing the symbol of `sun.misc.Unsafe` used in the project to not be found. There are two possible solutions:
 
-1. Set the Project SDK to 8, or
-2. In the `Java Compiler` panel of IDEA's `Preference`, turn off the `--release` option
+1. In IntelliJ IDEA, go to `Preferences` and find the `Java Compiler` panel. Then, disable the `--release` option, or
+2. Set the project's SDK to version 8 (not recommended).
 
 ### Reference
 

--- a/content/en/docs/contribution-guidelines/hugegraph-server-idea-setup.md
+++ b/content/en/docs/contribution-guidelines/hugegraph-server-idea-setup.md
@@ -113,9 +113,9 @@ At this point, you can view detailed variable information in the debugger.
 The reason may be that cross-compilation is triggered when using Java 11 to compile, causing the symbol of `sun.misc.Unsafe` used in the project to not be found. There are two possible solutions:
 
 1. In IntelliJ IDEA, go to `Preferences` and find the `Java Compiler` panel. Then, disable the `--release` option, or
-2. Set the project's SDK to version 8 (not recommended).
+2. Set the Project SDK to 8 (not recommended).
 
-### Reference
+### References
 
 1. [HugeGraph-Server Quick Start](/docs/quickstart/hugegraph-server/)
 2. [Local Debugging Guide for HugeGraph Server (Win/Unix)](https://gist.github.com/imbajin/1661450f000cd62a67e46d4f1abfe82c)

--- a/content/en/docs/contribution-guidelines/hugegraph-server-idea-setup.md
+++ b/content/en/docs/contribution-guidelines/hugegraph-server-idea-setup.md
@@ -1,0 +1,143 @@
+---
+title: "How to Set Up HugeGraph-Server Development Environment in IDEA"
+linkTitle: "How to Set Up HugeGraph-Server Development Environment in IDEA"
+weight: 4
+---
+
+> Note: The following configuration is for reference purposes only, and has been tested on Linux and macOS platforms based on [this version](https://github.com/apache/incubator-hugegraph/commit/a946ad1de4e8f922251a5241ffc957c33379677f).
+
+### Background
+
+The [Quick Start](/docs/quickstart/hugegraph-server/) section provides instructions on how to start and stop HugeGraphServer using scripts. However, for developers, this method may not be convenient as it is not integrated with IDE tools and can be difficult to debug. In this guide, we will explain how to run and debug HugeGraph-Server on the Linux platform using IntelliJ IDEA.
+
+The process of local startup is similar to **script startup** and involves the following steps:
+
+1. Initialize the database backend by executing the `InitStore` class to initialize the graph.
+2. Start HugeGraphServer by executing the `HugeGraphServer` class to load the initialized graph information and start the server.
+
+Before proceeding with the following process, make sure that you have cloned the source code of HugeGraph and have configured the development environment, such as JDK 11.
+
+```
+git clone https://github.com/apache/hugegraph.git
+cd hugegraph
+```
+
+### Steps
+
+#### 1. Copy Configuration Files
+
+To avoid the impact of configuration file changes on Git tracking, it is recommended to copy the required configuration files to a separate folder. Run the following command to copy the files:
+
+```
+cp -r hugegraph-dist/src/assembly/static/scripts hugegraph-dist/src/assembly/static/conf <path-to-your-directory>
+```
+
+Replace `<path-to-your-directory>` with the path to the directory where you want to copy the files.
+
+#### 2. Configure `InitStore`
+
+Next, you need to configure the database backend in the copied files. In this example, we will use RocksDB. Open `<path-to-your-directory>/conf/graphs/hugegraph.properties` and configure it as follows:
+
+```
+backend=rocksdb
+serializer=binary
+rocksdb.data_path=.
+rocksdb.wal_path=.
+```
+
+Then, open the `Run/Debug configurations` panel of IDEA and create a new `Application` with the following configurations:
+
+- Select `Use classpath of module` as `hugegraph-dist`
+- Set `Main class` to `org.apache.hugegraph.cmd.InitStore`
+- Set the running parameter to `conf/graphs/hugegraph.properties`. The path here is relative to the working directory, so you need to set the working directory to `<path-to-your-directory>`
+
+After the configuration is complete, run it. If the operation is successful, the following running log will be printed:
+
+```
+2023-06-05 00:43:37 [main] [INFO] o.a.h.u.ConfigUtil - Scanning option 'graphs' directory './conf/graphs'
+2023-06-05 00:43:37 [main] [INFO] o.a.h.c.InitStore - Init graph with config file: ./conf/graphs/hugegraph.properties
+2023-06-05 00:43:38 [db-open-1] [INFO] o.a.h.b.s.r.RocksDBStore - Opening RocksDB with data path: ./m
+2023-06-05 00:43:38 [db-open-1] [INFO] o.a.h.b.s.r.RocksDBStore - Failed to open RocksDB './m' with database 'hugegraph', try to init CF later
+2023-06-05 00:43:38 [main] [INFO] o.a.h.b.c.CacheManager - Init RamCache for 'schema-id-hugegraph' with capacity 10000
+2023-06-05 00:43:38 [main] [INFO] o.a.h.b.c.CacheManager - Init RamCache for 'schema-name-hugegraph' with capacity 10000
+2023-06-05 00:43:38 [db-open-1] [INFO] o.a.h.b.s.r.RocksDBStore - Opening RocksDB with data path: ./s
+main dict load finished, time elapsed 697 ms
+model load finished, time elapsed 64 ms.
+2023-06-05 00:43:39 [db-open-1] [INFO] o.a.h.b.s.r.RocksDBStore - Opening RocksDB with data path: ./g
+2023-06-05 00:43:39 [main] [INFO] o.c.o.l.Uns - OHC using JNA OS native malloc/free
+2023-06-05 00:43:39 [main] [INFO] o.a.h.b.c.CacheManager - Init LevelCache for 'vertex-hugegraph' with capacity 10000:10000000
+2023-06-05 00:43:39 [main] [INFO] o.a.h.b.c.CacheManager - Init LevelCache for 'edge-hugegraph' with capacity 1000:1000000
+2023-06-05 00:43:39 [main] [INFO] o.a.h.b.c.CacheManager - Init RamCache for 'users-hugegraph' with capacity 10240
+2023-06-05 00:43:39 [main] [INFO] o.a.h.b.c.CacheManager - Init RamCache for 'users_pwd-hugegraph' with capacity 10240
+2023-06-05 00:43:39 [main] [INFO] o.a.h.b.c.CacheManager - Init RamCache for 'token-hugegraph' with capacity 10240
+2023-06-05 00:43:39 [main] [INFO] o.a.h.b.s.r.RocksDBStore - Write down the backend version: 1.11
+2023-06-05 00:43:39 [main] [INFO] o.a.h.StandardHugeGraph - Graph 'hugegraph' has been initialized
+2023-06-05 00:43:39 [main] [INFO] o.a.h.StandardHugeGraph - Close graph standardhugegraph[hugegraph]
+2023-06-05 00:43:39 [db-open-1] [INFO] o.a.h.b.s.r.RocksDBStore - Opening RocksDB with data path: ./m
+2023-06-05 00:43:39 [db-open-1] [INFO] o.a.h.b.s.r.RocksDBStore - Opening RocksDB with data path: ./s
+2023-06-05 00:43:39 [db-open-1] [INFO] o.a.h.b.s.r.RocksDBStore - Opening RocksDB with data path: ./g
+2023-06-05 00:43:39 [main] [INFO] o.a.h.HugeFactory - HugeFactory shutdown
+2023-06-05 00:43:39 [hugegraph-shutdown] [INFO] o.a.h.HugeFactory - HugeGraph is shutting down
+```
+
+#### 3. Configure `HugeGraphServer`
+
+Similarly, open the `Run/Debug configurations` panel of IDEA and create a new `Application` with the following configurations:
+
+- Select `Use classpath of module` as `hugegraph-dist`
+- Set `Main class` to `org.apache.hugegraph.dist.HugeGraphServer`
+- Set the running parameter to `conf/gremlin-server.yaml conf/rest-server.properties`. Similarly, the path here is relative to the working directory, so you need to set the working directory to `<path-to-your-directory>`
+
+After the configuration is complete, run it. If you see the following log, it means that `HugeGraphServer` has been successfully started:
+
+```
+......
+2023-06-05 00:51:56 [gremlin-server-boss-1] [INFO] o.a.t.g.s.GremlinServer - Gremlin Server configured with worker thread pool of 1, gremlin pool of 8 and boss thread pool of 1.
+2023-06-05 00:51:56 [gremlin-server-boss-1] [INFO] o.a.t.g.s.GremlinServer - Channel started at port 8182.
+```
+
+#### 4. Debugging `HugeGraphServer`
+
+After completing the above configuration, you can try to debug `HugeGraphServer`. Run `HugeGraphServer` in debug mode, and set breakpoints at the corresponding [location](https://github.com/apache/hugegraph/blob/a946ad1de4e8f922251a5241ffc957c33379677f/hugegraph-api/src/main/java/org/apache/hugegraph/api/graph/VertexAPI.java#L238):
+
+```java
+@GET
+@Timed
+@Compress
+@Produces(APPLICATION_JSON_WITH_CHARSET)
+@RolesAllowed({"admin", "$owner=$graph $action=vertex_read"})
+public String list(@Context GraphManager manager,
+                   @PathParam("graph") String graph,
+                   @QueryParam("label") String label,
+                   @QueryParam("properties") String properties,
+                   @QueryParam("keep_start_p")
+                   @DefaultValue("false") boolean keepStartP,
+                   @QueryParam("offset") @DefaultValue("0") long offset,
+                   @QueryParam("page") String page,
+                   @QueryParam("limit") @DefaultValue("100") long limit) {
+    LOG.debug("Graph [{}] query vertices by label: {}, properties: {}, " +
+              "offset: {}, page: {}, limit: {}",
+              graph, label, properties, offset, page, limit);
+    Map<String, Object> props = parseProperties(properties);
+```
+Then use the RESTful API to request `HugeGraphServer`:
+```
+curl "http://localhost:8080/graphs/hugegraph/graph/vertices" | gunzip
+```
+At this point, you can view detailed variable information in the Debugger.
+
+### Possible Issues
+
+#### java: package sun.misc does not exist
+
+The reason may be that cross-compilation is triggered when using Java 11 to compile, causing the symbol of `sun.misc.Unsafe` used in the project to not be found. There are two solutions:
+
+1. Set the Project SDK to 8, or
+2. In the `Java Compiler` panel of IDEA's `Preference`, turn off the `--release` option
+
+### Reference
+
+1. [HugeGraph-Server Quick Start](/docs/quickstart/hugegraph-server/)
+2. [Local Debugging Guide for HugeGraph Server (Win/Unix)](https://gist.github.com/imbajin/1661450f000cd62a67e46d4f1abfe82c)
+3. ["package sun.misc does not exist" compilation error](https://youtrack.jetbrains.com/issue/IDEA-180033)
+4. [Cannot compile: java: package sun.misc does not exist](https://youtrack.jetbrains.com/issue/IDEA-201168)

--- a/content/en/docs/contribution-guidelines/hugegraph-server-idea-setup.md
+++ b/content/en/docs/contribution-guidelines/hugegraph-server-idea-setup.md
@@ -19,7 +19,6 @@ Before proceeding with the following process, make sure that you have cloned the
 
 ```bash
 git clone https://github.com/apache/hugegraph.git
-cd hugegraph
 ```
 
 ### Steps
@@ -29,14 +28,14 @@ cd hugegraph
 To avoid the impact of configuration file changes on Git tracking, it is recommended to copy the required configuration files to a separate folder. Run the following command to copy the files:
 
 ```bash
-cp -r hugegraph-dist/src/assembly/static/scripts hugegraph-dist/src/assembly/static/conf <path-to-your-directory>
+cp -r hugegraph-dist/src/assembly/static/scripts hugegraph-dist/src/assembly/static/conf path-to-your-directory
 ```
 
-Replace `<path-to-your-directory>` with the path to the directory where you want to copy the files.
+Replace `path-to-your-directory` with the path to the directory where you want to copy the files.
 
-#### 2. Configure `InitStore`
+#### 2. Configure `InitStore` to initialize the graph
 
-First, you need to configure the database backend in the configuration files. In this example, we will use RocksDB. Open `<path-to-your-directory>/conf/graphs/hugegraph.properties` and configure it as follows:
+First, you need to configure the database backend in the configuration files. In this example, we will use RocksDB. Open `path-to-your-directory/conf/graphs/hugegraph.properties` and configure it as follows:
 
 ```properties
 backend=rocksdb
@@ -49,7 +48,7 @@ Next, open the `Run/Debug Configurations` panel in IntelliJ IDEA and create a ne
 
 - Select `hugegraph-dist` as the `Use classpath of module`.
 - Set the `Main class` to `org.apache.hugegraph.cmd.InitStore`.
-- Set the program arguments to `conf/graphs/hugegraph.properties`. Note that the path here is relative to the working directory, so make sure to set the working directory to `<path-to-your-directory>`.
+- Set the program arguments to `conf/graphs/hugegraph.properties`. Note that the path here is relative to the working directory, so make sure to set the working directory to `path-to-your-directory`.
 
 Once the configuration is completed, run it. If the execution is successful, the following runtime logs will be displayed:
 
@@ -67,13 +66,13 @@ Once the configuration is completed, run it. If the execution is successful, the
 2023-06-05 00:43:39 [hugegraph-shutdown] [INFO] o.a.h.HugeFactory - HugeGraph is shutting down
 ```
 
-#### 3. Configure `HugeGraphServer`
+#### 3. Running `HugeGraphServer`
 
 Similarly, open the `Run/Debug Configurations` panel in IntelliJ IDEA and create a new `Application` configuration. Follow these steps for the configuration:
 
 - Select `hugegraph-dist` as the `Use classpath of module`.
 - Set the `Main class` to `org.apache.hugegraph.dist.HugeGraphServer`.
-- Set the program arguments to `conf/gremlin-server.yaml conf/rest-server.properties`. Similarly, note that the path here is relative to the working directory, so make sure to set the working directory to `<path-to-your-directory>`.
+- Set the program arguments to `conf/gremlin-server.yaml conf/rest-server.properties`. Similarly, note that the path here is relative to the working directory, so make sure to set the working directory to `path-to-your-directory`.
 
 Once the configuration is completed, run it. If you see the following logs, it means that `HugeGraphServer` has been successfully started:
 
@@ -89,12 +88,9 @@ After completing the above configuration, you can try debugging `HugeGraphServer
 
 ```java
 public String list(@Context GraphManager manager,
-                   @PathParam("graph") String graph,
-                   @QueryParam("label") String label,
-                   @QueryParam("properties") String properties,
-                   ......) {
-    ......
-
+                   @PathParam("graph") String graph, @QueryParam("label") String label,
+                   @QueryParam("properties") String properties, ......) {
+    // ignore log
     Map<String, Object> props = parseProperties(properties);
 ```
 
@@ -112,8 +108,8 @@ At this point, you can view detailed variable information in the debugger.
 
 The reason may be that cross-compilation is triggered when using Java 11 to compile, causing the symbol of `sun.misc.Unsafe` used in the project to not be found. There are two possible solutions:
 
-1. In IntelliJ IDEA, go to `Preferences` and find the `Java Compiler` panel. Then, disable the `--release` option, or
-2. Set the Project SDK to 8 (not recommended).
+1. In IntelliJ IDEA, go to `Preferences/Settings` and find the `Java Compiler` panel. Then, disable the `--release` option (recommended).
+2. Set the Project SDK to 8.
 
 ### References
 

--- a/content/en/docs/quickstart/hugegraph-server.md
+++ b/content/en/docs/quickstart/hugegraph-server.md
@@ -438,3 +438,7 @@ For detailed API, please refer to [RESTful-API](/docs/clients/restful-api)
 $cd hugegraph-${version}
 $bin/stop-hugegraph.sh
 ```
+
+### 8 Debug Server with IntelliJ IDEA
+
+Please refer to [How to Set Up HugeGraph-Server Development Environment in IDEA](/docs/contribution-guidelines/hugegraph-server-idea-setup)


### PR DESCRIPTION
The [Quick Start](https://hugegraph.apache.org/docs/quickstart/hugegraph-server/) section provides instructions on how to start and stop HugeGraphServer using scripts. However, for developers, this method may not be convenient as it is not integrated with IDE tools and can be difficult to debug. 

So I add a guide to explain how to run and debug HugeGraphServer on the Linux platform using IntelliJ IDEA.

I have read the CLA Document and I hereby sign the CLA