### PR TITLE
doc: update Log4j2 configuration and gremlin-console guide

### DIFF
--- a/content/cn/docs/clients/gremlin-console.md
+++ b/content/cn/docs/clients/gremlin-console.md
@@ -41,7 +41,6 @@ schema.propertyKey("price").asInt().ifNotExist().create()
 
 schema.vertexLabel("person").properties("name", "age", "city").primaryKeys("name").ifNotExist().create()
 schema.vertexLabel("software").properties("name", "lang", "price").primaryKeys("name").ifNotExist().create()
-// schema.indexLabel("personByName").onV("person").by("name").secondary().ifNotExist().create()
 schema.indexLabel("personByCity").onV("person").by("city").secondary().ifNotExist().create()
 schema.indexLabel("personByAgeAndCity").onV("person").by("age", "city").secondary().ifNotExist().create()
 schema.indexLabel("softwareByPrice").onV("software").by("price").range().ifNotExist().create()
@@ -124,7 +123,7 @@ gremlin>
 
 因为 Gremlin-Console 只能通过 WebSocket 连接 HugeGraph-Server，默认 HugeGraph-Server 是对外提供 HTTP 连接的，所以先修改 gremlin-server 的配置。
 
-*注意：将连接方式修改为 WebSocket 后，HugeGraph-Client、HugeGraph-Loader、HugeGraph-Studio 等配套工具都不能使用了。*
+*注意：将连接方式修改为 WebSocket 后，HugeGraph-Client、HugeGraph-Loader、HugeGraph-Hubble 等配套工具都不能使用了。*
 
 ```yaml
 # vim conf/gremlin-server.yaml
@@ -148,7 +147,7 @@ channelizer: org.apache.tinkerpop.gremlin.server.channel.HttpChannelizer
 plugin activated: HugeGraph
 plugin activated: tinkerpop.server
 plugin activated: tinkerpop.utilities
-plugin activated: tinkerpop.tinkergraph         
+plugin activated: tinkerpop.tinkergraph
 ```
 
 连接 server，需在配置文件中指定连接参数，在 conf 目录下有一个默认的 `remote.yaml`：
@@ -171,7 +170,7 @@ gremlin> :remote connect tinkerpop.server conf/remote.yaml
 ==>Configured localhost/127.0.0.1:8182
 ```
 
-连接成功之后，如果在启动 HugegraphServer 的过程中导入了示例图 `example.groovy`，就可以在 console 中直接进行查询
+连接成功之后，如果在启动 HugeGraphServer 的过程中导入了示例图 `example.groovy`，就可以在 console 中直接进行查询
 
 ```groovy
 gremlin> :> hugegraph.traversal().V()
@@ -183,7 +182,7 @@ gremlin> :> hugegraph.traversal().V()
 ==>[id:2:ripple,label:software,type:vertex,properties:[name:ripple,lang:java,price:199]]
 ```
 
-在 Client/Server 模式下，所有和 Server 有关的操作都要加上 `:> `，如果不加，表示在 console 本地操作。
+> 注意：在 Client/Server 模式下，所有和 Server 有关的操作都要加上 `:> `，如果不加，表示在 console 本地操作。
 
 还可以把多条语句放在一个字符串变量中，然后一次性发给 Server：
 

--- a/content/cn/docs/clients/gremlin-console.md
+++ b/content/cn/docs/clients/gremlin-console.md
@@ -4,305 +4,203 @@ linkTitle: "Gremlin Console"
 weight: 3
 ---
 
-Gremlin-Console是由Tinkerpop自己开发的一个交互式客户端，用户可以使用该客户端对Graph做各种操作，主要有两种使用模式：
+Gremlin-Console 是由 Tinkerpop 自己开发的一个交互式客户端，用户可以使用该客户端对 Graph 做各种操作，主要有两种使用模式：
 
-- 单机离线调用模式；
-- Client/Server请求模式；
+- 单机离线调用模式
+- Client/Server 请求模式
 
 ### 1 单机离线调用模式
 
-由于lib目录下已经包含了HugeCore的jar包，且HugeGraph已经作为插件注册到Console中，用户可以直接写groovy脚本调用HugeGraph-Core的代码，然后交由Gremlin-Console内的解析引擎执行，就能在不启动Server的情况下操作图。
+由于 lib 目录下已经包含了 HugeCore 的 jar 包，且 HugeGraph 已经作为插件注册到 Console 中，用户可以直接写 groovy 脚本调用 HugeGraph-Core 的代码，然后交由 Gremlin-Console 内的解析引擎执行，就能在不启动 Server 的情况下操作图。
 
 这种模式便于用户快速上手体验，但是不适合大量数据插入和查询的场景。下面给一个示例：
 
-在script目录下有一个示例脚本：example.groovy
+在 script 目录下有一个示例脚本 `example.groovy`：
 
 ```groovy
-import com.baidu.hugegraph.HugeFactory
-import com.baidu.hugegraph.dist.RegisterUtil
+import org.apache.hugegraph.HugeFactory
+import org.apache.hugegraph.backend.id.IdGenerator
+import org.apache.hugegraph.dist.RegisterUtil
+import org.apache.hugegraph.type.define.NodeRole
 import org.apache.tinkerpop.gremlin.structure.T
 
-RegisterUtil.registerCassandra();
-RegisterUtil.registerScyllaDB();
+RegisterUtil.registerRocksDB()
 
-conf = "conf/hugegraph.properties"
-graph = HugeFactory.open(conf);
-schema = graph.schema();
+conf = "conf/graphs/hugegraph.properties"
+graph = HugeFactory.open(conf)
+graph.serverStarted(IdGenerator.of("server-tinkerpop"), NodeRole.MASTER)
+schema = graph.schema()
 
-schema.propertyKey("name").asText().ifNotExist().create();
-schema.propertyKey("age").asInt().ifNotExist().create();
-schema.propertyKey("city").asText().ifNotExist().create();
-schema.propertyKey("weight").asDouble().ifNotExist().create();
-schema.propertyKey("lang").asText().ifNotExist().create();
-schema.propertyKey("date").asText().ifNotExist().create();
-schema.propertyKey("price").asInt().ifNotExist().create();
+schema.propertyKey("name").asText().ifNotExist().create()
+schema.propertyKey("age").asInt().ifNotExist().create()
+schema.propertyKey("city").asText().ifNotExist().create()
+schema.propertyKey("weight").asDouble().ifNotExist().create()
+schema.propertyKey("lang").asText().ifNotExist().create()
+schema.propertyKey("date").asText().ifNotExist().create()
+schema.propertyKey("price").asInt().ifNotExist().create()
 
-schema.vertexLabel("person").properties("name", "age", "city").primaryKeys("name").ifNotExist().create();
-schema.vertexLabel("software").properties("name", "lang", "price").primaryKeys("name").ifNotExist().create();
-schema.indexLabel("personByName").onV("person").by("name").secondary().ifNotExist().create();
-schema.indexLabel("personByCity").onV("person").by("city").secondary().ifNotExist().create();
-schema.indexLabel("personByAgeAndCity").onV("person").by("age", "city").secondary().ifNotExist().create();
-schema.indexLabel("softwareByPrice").onV("software").by("price").range().ifNotExist().create();
-schema.edgeLabel("knows").sourceLabel("person").targetLabel("person").properties("date", "weight").ifNotExist().create();
-schema.edgeLabel("created").sourceLabel("person").targetLabel("software").properties("date", "weight").ifNotExist().create();
-schema.indexLabel("createdByDate").onE("created").by("date").secondary().ifNotExist().create();
-schema.indexLabel("createdByWeight").onE("created").by("weight").range().ifNotExist().create();
-schema.indexLabel("knowsByWeight").onE("knows").by("weight").range().ifNotExist().create();
+schema.vertexLabel("person").properties("name", "age", "city").primaryKeys("name").ifNotExist().create()
+schema.vertexLabel("software").properties("name", "lang", "price").primaryKeys("name").ifNotExist().create()
+// schema.indexLabel("personByName").onV("person").by("name").secondary().ifNotExist().create()
+schema.indexLabel("personByCity").onV("person").by("city").secondary().ifNotExist().create()
+schema.indexLabel("personByAgeAndCity").onV("person").by("age", "city").secondary().ifNotExist().create()
+schema.indexLabel("softwareByPrice").onV("software").by("price").range().ifNotExist().create()
+schema.edgeLabel("knows").sourceLabel("person").targetLabel("person").properties("date", "weight").ifNotExist().create()
+schema.edgeLabel("created").sourceLabel("person").targetLabel("software").properties("date", "weight").ifNotExist().create()
+schema.indexLabel("createdByDate").onE("created").by("date").secondary().ifNotExist().create()
+schema.indexLabel("createdByWeight").onE("created").by("weight").range().ifNotExist().create()
+schema.indexLabel("knowsByWeight").onE("knows").by("weight").range().ifNotExist().create()
 
-marko = graph.addVertex(T.label, "person", "name", "marko", "age", 29, "city", "Beijing");
-vadas = graph.addVertex(T.label, "person", "name", "vadas", "age", 27, "city", "Hongkong");
-lop = graph.addVertex(T.label, "software", "name", "lop", "lang", "java", "price", 328);
-josh = graph.addVertex(T.label, "person", "name", "josh", "age", 32, "city", "Beijing");
-ripple = graph.addVertex(T.label, "software", "name", "ripple", "lang", "java", "price", 199);
-peter = graph.addVertex(T.label, "person", "name", "peter", "age", 35, "city", "Shanghai");
+marko = graph.addVertex(T.label, "person", "name", "marko", "age", 29, "city", "Beijing")
+vadas = graph.addVertex(T.label, "person", "name", "vadas", "age", 27, "city", "Hongkong")
+lop = graph.addVertex(T.label, "software", "name", "lop", "lang", "java", "price", 328)
+josh = graph.addVertex(T.label, "person", "name", "josh", "age", 32, "city", "Beijing")
+ripple = graph.addVertex(T.label, "software", "name", "ripple", "lang", "java", "price", 199)
+peter = graph.addVertex(T.label, "person", "name", "peter", "age", 35, "city", "Shanghai")
 
-marko.addEdge("knows", vadas, "date", "20160110", "weight", 0.5);
-marko.addEdge("knows", josh, "date", "20130220", "weight", 1.0);
-marko.addEdge("created", lop, "date", "20171210", "weight", 0.4);
-josh.addEdge("created", lop, "date", "20091111", "weight", 0.4);
-josh.addEdge("created", ripple, "date", "20171210", "weight", 1.0);
-peter.addEdge("created", lop, "date", "20170324", "weight", 0.2);
+marko.addEdge("knows", vadas, "date", "20160110", "weight", 0.5)
+marko.addEdge("knows", josh, "date", "20130220", "weight", 1.0)
+marko.addEdge("created", lop, "date", "20171210", "weight", 0.4)
+josh.addEdge("created", lop, "date", "20091111", "weight", 0.4)
+josh.addEdge("created", ripple, "date", "20171210", "weight", 1.0)
+peter.addEdge("created", lop, "date", "20170324", "weight", 0.2)
 
-graph.tx().commit();
+graph.tx().commit()
 
-g = graph.traversal();
+g = graph.traversal()
 
-System.out.println(">>>> query all vertices: size=" + g.V().toList().size());
-System.out.println(">>>> query all edges: size=" + g.E().toList().size());
+System.out.println(">>>> query all vertices: size=" + g.V().toList().size())
+System.out.println(">>>> query all edges: size=" + g.E().toList().size())
 ```
 
-其实这一段groovy脚本几乎就是Java代码，不同之处仅在于变量的定义可以不写类型声明，以及每一行末尾的分号可以去掉。
+其实这一段 groovy 脚本几乎就是 Java 代码，不同之处仅在于变量的定义可以不写类型声明，以及每一行末尾的分号可以去掉。
 
-> g.V() 是获取所有的顶点，g.E() 是获取所有的边，toList() 是把结果存到一个 List 中，参考[TinkerPop Terminal Steps](http://tinkerpop.apache.org/docs/current/reference/#terminal-steps)。
+> `g.V()` 是获取所有的顶点，`g.E()` 是获取所有的边，`toList()` 是把结果存到一个 List 中，参考 [TinkerPop Terminal Steps](http://tinkerpop.apache.org/docs/current/reference/#terminal-steps)。
 
-下面进入gremlin-console，并传入该脚本令其执行：
+下面进入 gremlin-console，并传入该脚本令其执行：
 
 ```bash
-bin/gremlin-console.sh scripts/example.groovy
-objc[5038]: Class JavaLaunchHelper is implemented in both /Library/Java/JavaVirtualMachines/jdk1.8.0_121.jdk/Contents/Home/bin/java (0x10137a4c0) and /Library/Java/JavaVirtualMachines/jdk1.8.0_121.jdk/Contents/Home/jre/lib/libinstrument.dylib (0x102bbb4e0). One of the two will be used. Which one is undefined.
+> ./bin/gremlin-console.sh -- -i scripts/example.groovy
 
          \,,,/
          (o o)
 -----oOOo-(3)-oOOo-----
-plugin activated: com.baidu.hugegraph
+plugin activated: HugeGraph
 plugin activated: tinkerpop.server
 plugin activated: tinkerpop.utilities
 plugin activated: tinkerpop.tinkergraph
-2018-01-15 14:36:19 7516  [main] [WARN ] com.baidu.hugegraph.config.HugeConfig [] - The config option 'rocksdb.data_path' is redundant, please ensure it has been registered
-2018-01-15 14:36:19 7523  [main] [WARN ] com.baidu.hugegraph.config.HugeConfig [] - The config option 'rocksdb.wal_path' is redundant, please ensure it has been registered
-2018-01-15 14:36:19 7604  [main] [INFO ] com.baidu.hugegraph.HugeGraph [] - Opening backend store 'cassandra' for graph 'hugegraph'
+main dict load finished, time elapsed 644 ms
+model load finished, time elapsed 35 ms.
 >>>> query all vertices: size=6
 >>>> query all edges: size=6
+gremlin> 
 ```
 
-可以看到，插入了6个顶点、6条边，并查询出来了。进入console之后，还可继续输入groovy语句对图做操作：
+> 这里的 `--` 会被 getopts 解析为最后一个 option，这样后面的 options 就可以传入 Gremlin-Console 进行处理了。`-i` 代表 `Execute the specified script and leave the console open on completion`，更多的选项可以参考 Gremlin-Console 的[源代码](https://github.com/apache/tinkerpop/blob/3.5.1/gremlin-console/src/main/groovy/org/apache/tinkerpop/gremlin/console/Console.groovy#L483)。
+
+可以看到，插入了 6 个顶点、6 条边，并查询出来了。进入 console 之后，还可继续输入 groovy 语句对图做操作：
 
 ```groovy
 gremlin> g.V()
-==>v[2:ripple]
-==>v[1:vadas]
-==>v[1:peter]
+==>v[2:lop]
 ==>v[1:josh]
 ==>v[1:marko]
-==>v[2:lop]
+==>v[1:peter]
+==>v[1:vadas]
+==>v[2:ripple]
 gremlin> g.E()
-==>e[S1:josh>2>>S2:ripple][1:josh-created->2:ripple]
-==>e[S1:marko>1>20160110>S1:vadas][1:marko-knows->1:vadas]
-==>e[S1:peter>2>>S2:lop][1:peter-created->2:lop]
 ==>e[S1:josh>2>>S2:lop][1:josh-created->2:lop]
-==>e[S1:marko>1>20130220>S1:josh][1:marko-knows->1:josh]
+==>e[S1:josh>2>>S2:ripple][1:josh-created->2:ripple]
+==>e[S1:marko>1>>S1:josh][1:marko-knows->1:josh]
+==>e[S1:marko>1>>S1:vadas][1:marko-knows->1:vadas]
 ==>e[S1:marko>2>>S2:lop][1:marko-created->2:lop]
+==>e[S1:peter>2>>S2:lop][1:peter-created->2:lop]
+gremlin> 
 ```
 
-更多的Gremlin语句请参考[Tinkerpop官网](http://tinkerpop.apache.org/docs/current/reference/)
+更多的 Gremlin 语句请参考 [Tinkerpop 官网](http://tinkerpop.apache.org/docs/current/reference/)。
 
-### 2 Client/Server请求模式
+### 2 Client/Server 请求模式
 
-因为Gremlin-Console只能通过WebSocket连接HugeGraph-Server，默认HugeGraph-Server是对外提供HTTP连接的，所以先修改gremlin-server的配置。
+因为 Gremlin-Console 只能通过 WebSocket 连接 HugeGraph-Server，默认 HugeGraph-Server 是对外提供 HTTP 连接的，所以先修改 gremlin-server 的配置。
 
-*注意：将连接方式修改为WebSocket后，HugeGraph-Client、HugeGraph-Loader、HugeGraph-Studio等配套工具都不能使用了。*
+*注意：将连接方式修改为 WebSocket 后，HugeGraph-Client、HugeGraph-Loader、HugeGraph-Studio 等配套工具都不能使用了。*
 
 ```yaml
 # vim conf/gremlin-server.yaml
-host: 127.0.0.1
-port: 8182
-scriptEvaluationTimeout: 30000
-# If you want to start gremlin-server for gremlin-console(web-socket),
+# ......
+# If you want to start gremlin-server for gremlin-console (web-socket),
 # please change `HttpChannelizer` to `WebSocketChannelizer` or comment this line.
 channelizer: org.apache.tinkerpop.gremlin.server.channel.HttpChannelizer
-graphs: {
-  hugegraph: conf/hugegraph.properties,
-  hugegraph1: conf/hugegraph1.properties
-}
-plugins:
-  - com.baidu.hugegraph
-scriptEngines: {
-  gremlin-groovy: {
-    imports: [java.lang.Math],
-    staticImports: [java.lang.Math.PI],
-    scripts: [scripts/empty-sample.groovy]
-  }
-}
-serializers:
-  - { className: org.apache.tinkerpop.gremlin.driver.ser.GryoLiteMessageSerializerV1d0,
-      config: {
-        serializeResultToString: false,
-        ioRegistries: [com.baidu.hugegraph.io.HugeGraphIoRegistry]
-      }
-    }
-  - { className: org.apache.tinkerpop.gremlin.driver.ser.GryoMessageSerializerV1d0,
-      config: {
-        serializeResultToString: true,
-        ioRegistries: [com.baidu.hugegraph.io.HugeGraphIoRegistry]
-      }
-    }
-  - { className: org.apache.tinkerpop.gremlin.driver.ser.GraphSONMessageSerializerGremlinV1d0,
-      config: {
-        serializeResultToString: false,
-        ioRegistries: [com.baidu.hugegraph.io.HugeGraphIoRegistry]
-      }
-    }
-  - { className: org.apache.tinkerpop.gremlin.driver.ser.GraphSONMessageSerializerGremlinV2d0,
-      config: {
-        serializeResultToString: false,
-        ioRegistries: [com.baidu.hugegraph.io.HugeGraphIoRegistry]
-      }
-    }
-  - { className: org.apache.tinkerpop.gremlin.driver.ser.GraphSONMessageSerializerV1d0,
-      config: {
-        serializeResultToString: false,
-        ioRegistries: [com.baidu.hugegraph.io.HugeGraphIoRegistry]
-      }
-    }
-metrics: {
-  consoleReporter: {enabled: false, interval: 180000},
-  csvReporter: {enabled: true, interval: 180000, fileName: /tmp/gremlin-server-metrics.csv},
-  jmxReporter: {enabled: false},
-  slf4jReporter: {enabled: false, interval: 180000},
-  gangliaReporter: {enabled: false, interval: 180000, addressingMode: MULTICAST},
-  graphiteReporter: {enabled: false, interval: 180000}
-}
-maxInitialLineLength: 4096
-maxHeaderSize: 8192
-maxChunkSize: 8192
-maxContentLength: 65536
-maxAccumulationBufferComponents: 1024
-resultIterationBatchSize: 64
-writeBufferLowWaterMark: 32768
-writeBufferHighWaterMark: 65536
-ssl: {
-  enabled: false
-}
+# ......
 ```
 
-将`channelizer: org.apache.tinkerpop.gremlin.server.channel.HttpChannelizer`修改成`channelizer: org.apache.tinkerpop.gremlin.server.channel.WebSocketChannelizer`或直接注释，然后按照步骤启动Server。
+将 `channelizer: org.apache.tinkerpop.gremlin.server.channel.HttpChannelizer` 修改成 `channelizer: org.apache.tinkerpop.gremlin.server.channel.WebSocketChannelizer` 或直接注释，然后按照[步骤](/docs/quickstart/hugegraph-server/)启动 HugegraphServer。
 
-然后进入gremlin-console
+下面进入 gremlin-console：
 
 ```bash
-bin/gremlin-console.sh 
-objc[5761]: Class JavaLaunchHelper is implemented in both /Library/Java/JavaVirtualMachines/jdk1.8.0_121.jdk/Contents/Home/bin/java (0x10ec584c0) and /Library/Java/JavaVirtualMachines/jdk1.8.0_121.jdk/Contents/Home/jre/lib/libinstrument.dylib (0x10ecdc4e0). One of the two will be used. Which one is undefined.
+> ./bin/gremlin-console.sh
 
          \,,,/
          (o o)
 -----oOOo-(3)-oOOo-----
-plugin activated: com.baidu.hugegraph
+plugin activated: HugeGraph
 plugin activated: tinkerpop.server
 plugin activated: tinkerpop.utilities
-plugin activated: tinkerpop.tinkergraph
+plugin activated: tinkerpop.tinkergraph         
 ```
 
-连接server，需在配置文件中指定连接参数，在conf目录下有一个默认的remote.yaml
+连接 server，需在配置文件中指定连接参数，在 conf 目录下有一个默认的 `remote.yaml`：
 
 ```yaml
 # cat conf/remote.yaml
 hosts: [localhost]
 port: 8182
 serializer: {
-  className: org.apache.tinkerpop.gremlin.driver.ser.GryoMessageSerializerV1d0,
+  className: org.apache.tinkerpop.gremlin.driver.ser.GraphSONMessageSerializerV1d0,
   config: {
-    serializeResultToString: true,
-    ioRegistries: [com.baidu.hugegraph.io.HugeGraphIoRegistry]
+    serializeResultToString: false,
+    ioRegistries: [org.apache.hugegraph.io.HugeGraphIoRegistry]
   }
 }
 ```
 
 ```groovy
 gremlin> :remote connect tinkerpop.server conf/remote.yaml
-2018-01-15 15:30:31 11528 [main] [INFO ] org.apache.tinkerpop.gremlin.driver.Connection [] - Created new connection for ws://localhost:8182/gremlin
-2018-01-15 15:30:31 11538 [main] [INFO ] org.apache.tinkerpop.gremlin.driver.Connection [] - Created new connection for ws://localhost:8182/gremlin
-2018-01-15 15:30:31 11538 [main] [INFO ] org.apache.tinkerpop.gremlin.driver.ConnectionPool [] - Opening connection pool on Host{address=localhost/127.0.0.1:8182, hostUri=ws://localhost:8182/gremlin} with core size of 2
 ==>Configured localhost/127.0.0.1:8182
 ```
 
-连接成功之后，在console的上下文中能使用的变量只有hugegraph和hugegraph1两个图对象（在gremlin-server.yaml中配置），如果想拥有更多的变量，可以在`scripts/empty-sample.groovy`中添加，如:
-
-```groovy
-import org.apache.tinkerpop.gremlin.server.util.LifeCycleHook
-
-// an init script that returns a Map allows explicit setting of global bindings.
-def globals = [:]
-
-// defines a sample LifeCycleHook that prints some output to the Gremlin Server console.
-// note that the name of the key in the "global" map is unimportant.
-globals << [hook: [
-        onStartUp : { ctx ->
-            ctx.logger.info("Executed once at startup of Gremlin Server.")
-        },
-        onShutDown: { ctx ->
-            ctx.logger.info("Executed once at shutdown of Gremlin Server.")
-        }
-] as LifeCycleHook]
-
-// define schema manger for hugegraph
-schema = hugegraph.schema()
-// define the default TraversalSource to bind queries to - this one will be named "g".
-g = hugegraph.traversal()
-```
-
-这样在console中便可以直接使用schema和g这两个对象，做元数据的管理和图的查询了。
-
-不定义了也没关系，因为所有的对象都可以通过graph获得，例如：
+连接成功之后，如果在启动 HugegraphServer 的过程中导入了示例图 `example.groovy`，就可以在 console 中直接进行查询
 
 ```groovy
 gremlin> :> hugegraph.traversal().V()
-==>v[2:ripple]
-==>v[1:vadas]
-==>v[1:peter]
-==>v[1:josh]
-==>v[1:marko]
-==>v[2:lop]
+==>[id:2:lop,label:software,type:vertex,properties:[name:lop,lang:java,price:328]]
+==>[id:1:josh,label:person,type:vertex,properties:[name:josh,age:32,city:Beijing]]
+==>[id:1:marko,label:person,type:vertex,properties:[name:marko,age:29,city:Beijing]]
+==>[id:1:peter,label:person,type:vertex,properties:[name:peter,age:35,city:Shanghai]]
+==>[id:1:vadas,label:person,type:vertex,properties:[name:vadas,age:27,city:Hongkong]]
+==>[id:2:ripple,label:software,type:vertex,properties:[name:ripple,lang:java,price:199]]
 ```
 
-在Client/Server模式下，所有跟Server有关的操作都要加上`:> `，如果不加，表示在console本地操作。
+在 Client/Server 模式下，所有和 Server 有关的操作都要加上 `:> `，如果不加，表示在 console 本地操作。
 
-还可以把多条语句放在一个字符串变量中，然后一次性发给server：
+还可以把多条语句放在一个字符串变量中，然后一次性发给 Server：
 
 ```groovy
 gremlin> script = """
+......1> graph = hugegraph;
+......2> g = graph.traversal();
+......3> g.V().toList().size();
+......4> """
+==>
 graph = hugegraph;
-marko = graph.addVertex(T.label, "person", "name", "marko", "age", 29, "city", "Beijing");
-vadas = graph.addVertex(T.label, "person", "name", "vadas", "age", 27, "city", "Hongkong");
-lop = graph.addVertex(T.label, "software", "name", "lop", "lang", "java", "price", 328);
-josh = graph.addVertex(T.label, "person", "name", "josh", "age", 32, "city", "Beijing");
-ripple = graph.addVertex(T.label, "software", "name", "ripple", "lang", "java", "price", 199);
-peter = graph.addVertex(T.label, "person", "name", "peter", "age", 35, "city", "Shanghai");
-
-marko.addEdge("knows", vadas, "date", "20160110", "weight", 0.5);
-marko.addEdge("knows", josh, "date", "20130220", "weight", 1.0);
-marko.addEdge("created", lop, "date", "20171210", "weight", 0.4);
-josh.addEdge("created", lop, "date", "20091111", "weight", 0.4);
-josh.addEdge("created", ripple, "date", "20171210", "weight", 1.0);
-peter.addEdge("created", lop, "date", "20170324", "weight", 0.2);
-
-graph.tx().commit();
-
 g = graph.traversal();
 g.V().toList().size();
-"""
 
 gremlin> :> @script
 ==>6
+gremlin> 
 ```
 
-更多关于gremlin-console的使用，请参考[Tinkerpop官网](http://tinkerpop.apache.org/docs/current/reference/)
+更多关于 gremlin-console 的使用，请参考 [Tinkerpop 官网](http://tinkerpop.apache.org/docs/current/reference/)

--- a/content/cn/docs/contribution-guidelines/hugegraph-server-idea-setup.md
+++ b/content/cn/docs/contribution-guidelines/hugegraph-server-idea-setup.md
@@ -102,14 +102,28 @@ curl "http://localhost:8080/graphs/hugegraph/graph/vertices" | gunzip
 
 此时，可以在调试器中查看详细的变量信息。
 
+#### 5. Log4j2 日志配置
+
+默认情况下，运行 `InitStore` 和 `HugeGraphServer` 时，读取的 Log4j2 配置文件路径为 `hugegraph-dist/src/main/resources/log4j2.xml`，而不是 `path-to-your-directory/conf/log4j2.xml`，这个配置文件是使用**脚本**启动 HugeGraphServer 时读取的。
+
+为了避免同时维护两份配置文件，可以考虑在 **IntelliJ IDEA** 运行与调试 HugeGraphServer 时，修改读取的 Log4j2 配置文件路径：
+
+1. 打开之前创建的 `Application` 配置
+2. 点击 `Modify options` - `Add VM options`
+3. 设置 VM options 为 `-Dlog4j.configurationFile=conf/log4j2.xml`
+
 ### 可能遇到的问题
 
-*** java: package sun.misc does not exist ***
+#### java: package sun.misc does not exist
 
 原因可能是在使用 Java 11 编译时触发了交叉编译，导致项目中使用的 `sun.misc.Unsafe` 找不到符号。有两种解决方案可供选择：
 
 1. 在 IntelliJ IDEA 的 `Preferences/Settings` 中找到 `Java Compiler` 面板，然后关闭 `--release` 选项 (推荐)
 2. 或者将项目的 SDK 版本设置为 8
+
+#### Log4j2 日志无法打印 %l 等位置信息
+
+这是因为 Log4j2 中使用了 asynchronous loggers，可以参考[官方文档](https://logging.apache.org/log4j/2.x/manual/layouts.html#LocationInformation)进行配置
 
 ##### 参考
 

--- a/content/cn/docs/contribution-guidelines/hugegraph-server-idea-setup.md
+++ b/content/cn/docs/contribution-guidelines/hugegraph-server-idea-setup.md
@@ -1,6 +1,6 @@
 ---
-title: "在 IDEA 中配置 HugeGraph-Server 开发环境"
-linkTitle: "在 IDEA 中配置 HugeGraph-Server 开发环境"
+title: "在 IDEA 中配置 Server 开发环境"
+linkTitle: "在 IDEA 中配置 Server 开发环境"
 weight: 4
 ---
 

--- a/content/cn/docs/quickstart/hugegraph-server.md
+++ b/content/cn/docs/quickstart/hugegraph-server.md
@@ -432,3 +432,60 @@ $bin/stop-hugegraph.sh
 ### 8 使用 IntelliJ IDEA 调试 Server
 
 请参考[如何在 IDEA 中搭建 HugeGraph-Server 开发环境](/docs/contribution-guidelines/hugegraph-server-idea-setup)
+
+### 9 在启动 Server 时创建示例图
+
+修改 `conf/gremlin-server.yaml`，将 `empty-sample.groovy` 修改为 `example.groovy`：
+
+```yaml
+org.apache.tinkerpop.gremlin.jsr223.ScriptFileGremlinPlugin: {
+    files: [scripts/example.groovy]
+}
+```
+
+修改 `scripts/example.groovy`，将：
+
+```groovy
+RegisterUtil.registerRocksDB()
+conf = "conf/graphs/hugegraph.properties"
+graph = HugeFactory.open(conf)
+graph.serverStarted(IdGenerator.of("server-tinkerpop"), NodeRole.MASTER)
+schema = graph.schema()
+```
+
+修改为：
+
+```groovy
+conf = "conf/graphs/hugegraph.properties"
+graph = HugeFactory.open(conf)
+schema = graph.schema()
+```
+
+然后使用脚本启动 HugeGraph-Server，如果打印出类似日志：
+
+```java
+2023-06-10 19:41:14 [main] [INFO] o.a.h.d.HugeGremlinServer [org.apache.hugegraph.dist.HugeGremlinServer.start(HugeGremlinServer.java:38)] - 3.5.1
+         \,,,/
+         (o o)
+-----oOOo-(3)-oOOo-----
+
+2023-06-10 19:41:14 [main] [INFO] o.a.h.u.ConfigUtil [org.apache.hugegraph.util.ConfigUtil.scanGraphsDir(ConfigUtil.java:88)] - Scanning option 'graphs' directory './conf/graphs'
+2023-06-10 19:41:14 [main] [INFO] o.a.h.d.HugeGremlinServer [org.apache.hugegraph.dist.HugeGremlinServer.start(HugeGremlinServer.java:52)] - Configuring Gremlin Server from /Users/dingyuchen/Desktop/hugegraph/apache-hugegraph-incubating-1.0.0/conf/gremlin-server.yaml
+>>>> query all vertices: size=6
+>>>> query all edges: size=6
+```
+
+并且使用 RESTful API 请求 `HugeGraphServer` 得到如下结果：
+
+```json
+> curl "http://localhost:8080/graphs/hugegraph/graph/vertices" | gunzip
+
+  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
+                                 Dload  Upload   Total   Spent    Left  Speed
+100   222  100   222    0     0   3163      0 --:--:-- --:--:-- --:--:--  3964
+{"vertices":[{"id":"2:lop","label":"software","type":"vertex","properties":{"name":"lop","lang":"java","price":328}},{"id":"1:josh","label":"person","type":"vertex","properties":{"name":"josh","age":32,"city":"Beijing"}},{"id":"1:marko","label":"person","type":"vertex","properties":{"name":"marko","age":29,"city":"Beijing"}},{"id":"1:peter","label":"person","type":"vertex","properties":{"name":"peter","age":35,"city":"Shanghai"}},{"id":"1:vadas","label":"person","type":"vertex","properties":{"name":"vadas","age":27,"city":"Hongkong"}},{"id":"2:ripple","label":"software","type":"vertex","properties":{"name":"ripple","lang":"java","price":199}}]}
+```
+
+代表创建示例图成功。
+
+> 使用 IntelliJ IDEA 在启动 Server 时创建示例图的流程类似，不再赘述。

--- a/content/cn/docs/quickstart/hugegraph-server.md
+++ b/content/cn/docs/quickstart/hugegraph-server.md
@@ -4,29 +4,29 @@ linkTitle: "Install HugeGraph-Server"
 weight: 1
 ---
 
-### 1 HugeGraph-Server概述
+### 1 HugeGraph-Server 概述
 
-HugeGraph-Server 是 HugeGraph 项目的核心部分，包含Core、Backend、API等子模块。
+HugeGraph-Server 是 HugeGraph 项目的核心部分，包含 Core、Backend、API 等子模块。
 
-Core模块是Tinkerpop接口的实现，Backend模块用于管理数据存储，目前支持的后端包括：Memory、Cassandra、ScyllaDB以及RocksDB，API模块提供HTTP Server，将Client的HTTP请求转化为对Core的调用。
+Core 模块是 Tinkerpop 接口的实现，Backend 模块用于管理数据存储，目前支持的后端包括：Memory、Cassandra、ScyllaDB 以及 RocksDB，API 模块提供 HTTP Server，将 Client 的 HTTP 请求转化为对 Core 的调用。
 
-> 文档中会大量出现`HugeGraph-Server`及`HugeGraphServer`这两种写法，其他组件也类似。这两种写法含义上并无大的差异，可以这么区分：`HugeGraph-Server`表示服务端相关组件代码，`HugeGraphServer`表示服务进程。
+> 文档中会大量出现 `HugeGraph-Server` 及 `HugeGraphServer` 这两种写法，其他组件也类似。这两种写法含义上并无大的差异，可以这么区分：`HugeGraph-Server` 表示服务端相关组件代码，`HugeGraphServer` 表示服务进程。
 
 ### 2 依赖
 
 #### 2.1 安装 Java 11 (JDK 11)
 
-请优先考虑在 Java11 的环境上启动 `HugeGraph-Server`, 目前同时保留对 Java8 的兼容 
+请优先考虑在 Java11 的环境上启动 `HugeGraph-Server`，目前同时保留对 Java8 的兼容
 
-**在往下阅读之前务必执行`java -version`命令查看jdk版本**
+**在往下阅读之前务必执行 `java -version` 命令查看 jdk 版本**
 
 ```bash
 java -version
 ```
 
-#### 2.2 安装GCC-4.3.0(GLIBCXX_3.4.10)或更新版本（可选）
+#### 2.2 安装 GCC-4.3.0 (GLIBCXX_3.4.10) 或更新版本（可选）
 
-如果使用的是RocksDB后端，请务必执行`gcc --version`命令查看gcc版本；若使用其他后端，则不需要。
+如果使用的是 RocksDB 后端，请务必执行 `gcc --version` 命令查看 gcc 版本；若使用其他后端，则不需要。
 
 ```bash
 gcc --version
@@ -34,17 +34,16 @@ gcc --version
 
 ### 3 部署
 
-有三种方式可以部署HugeGraph-Server组件：
+有三种方式可以部署 HugeGraph-Server 组件：
 
-- 方式1：一键部署
-- 方式2：下载tar包
-- 方式3：源码编译
-- 方式4：使用Docker容器
+- 方式 1：一键部署
+- 方式 2：下载 tar 包
+- 方式 3：源码编译
+- 方式 4：使用 Docker 容器
 
 #### 3.1 一键部署
 
-HugeGraph-Tools 提供了一键部署的命令行工具，用户可以使用该工具快速地一键下载、解压、配置并启动 HugeGraph-Server 和 HugeGraph-Hubble
-最新的 HugeGraph-Toolchain 中已经包含所有的这些工具, 直接下载它解压就有工具包集合了
+HugeGraph-Tools 提供了一键部署的命令行工具，用户可以使用该工具快速地一键下载、解压、配置并启动 HugeGraph-Server 和 HugeGraph-Hubble，最新的 HugeGraph-Toolchain 中已经包含所有的这些工具，直接下载它解压就有工具包集合了
 
 ```bash
 # download toolchain package, it includes loader + tool + hubble, please check the latest version (here is 1.0.0)
@@ -54,17 +53,17 @@ tar zxf *hugegraph-*.tar.gz
 cd *hugegraph*/*tool* 
 ```
 
-> 注：${version}为版本号，最新版本号可参考[Download页面](/docs/download/download)，或直接从Download页面点击链接下载
+> 注：`${version}` 为版本号，最新版本号可参考 [Download 页面](/docs/download/download)，或直接从 Download 页面点击链接下载
 
-HugeGraph-Tools 的总入口脚本是`bin/hugegraph`，用户可以使用`help`子命令查看其用法，这里只介绍一键部署的命令。
+HugeGraph-Tools 的总入口脚本是 `bin/hugegraph`，用户可以使用 `help` 子命令查看其用法，这里只介绍一键部署的命令。
 
 ```bash
 bin/hugegraph deploy -v {hugegraph-version} -p {install-path} [-u {download-path-prefix}]
 ```
 
-`{hugegraph-version}`表示要部署的HugeGraphServer及HugeGraphStudio的版本，用户可查看`conf/version-mapping.yaml`文件获取版本信息，`{install-path}`指定HugeGraphServer及HugeGraphStudio的安装目录，`{download-path-prefix}`可选，指定HugeGraphServer及HugeGraphStudio tar包的下载地址，不提供时使用默认下载地址，比如要启动 0.6 版本的HugeGraph-Server及HugeGraphStudio将上述命令写为`bin/hugegraph deploy -v 0.6 -p services`即可。
+`{hugegraph-version}` 表示要部署的 HugeGraphServer 及 HugeGraphStudio 的版本，用户可查看 `conf/version-mapping.yaml` 文件获取版本信息，`{install-path}` 指定 HugeGraphServer 及 HugeGraphStudio 的安装目录，`{download-path-prefix}` 可选，指定 HugeGraphServer 及 HugeGraphStudio tar 包的下载地址，不提供时使用默认下载地址，比如要启动 0.6 版本的 HugeGraph-Server 及 HugeGraphStudio 将上述命令写为 `bin/hugegraph deploy -v 0.6 -p services` 即可。
 
-#### 3.2 下载tar包
+#### 3.2 下载 tar 包
 
 ```bash
 # use the latest version, here is 1.0.0 for example
@@ -74,15 +73,15 @@ tar zxf *hugegraph*.tar.gz
 
 #### 3.3 源码编译
 
-源码编译前请确保安装了wget命令
+源码编译前请确保安装了 wget 命令
 
-下载HugeGraph源代码
+下载 HugeGraph 源代码
 
 ```bash
 git clone https://github.com/apache/hugegraph.git
 ```
 
-编译打包生成tar包
+编译打包生成 tar 包
 
 ```bash
 cd hugegraph
@@ -112,26 +111,27 @@ mvn package -DskipTests
 ......
 ```
 
-执行成功后，在hugegraph目录下生成 hugegraph-*.tar.gz 文件，就是编译生成的tar包。
+执行成功后，在 hugegraph 目录下生成 hugegraph-*.tar.gz 文件，就是编译生成的 tar 包。
 
-#### 3.4 使用Docker容器
+#### 3.4 使用 Docker 容器
 
-可参考[Docker部署方式](https://hub.docker.com/r/hugegraph/hugegraph)。
+可参考 [Docker 部署方式](https://hub.docker.com/r/hugegraph/hugegraph)。
 
 ### 4 配置
 
-如果需要快速启动HugeGraph仅用于测试，那么只需要进行少数几个配置项的修改即可（见下一节）。
-详细的配置介绍请参考[配置文档](/docs/config/config-guide)及[配置项介绍](/docs/config/config-option)
+如果需要快速启动 HugeGraph 仅用于测试，那么只需要进行少数几个配置项的修改即可（见下一节）。
+
+详细的配置介绍请参考[配置文档](/docs/config/config-guide)及[配置项介绍](/docs/config/config-option)。
 
 ### 5 启动
 
 启动分为"首次启动"和"非首次启动"，这么区分是因为在第一次启动前需要初始化后端数据库，然后启动服务。
+
 而在人为停掉服务后，或者其他原因需要再次启动服务时，因为后端数据库是持久化存在的，直接启动服务即可。
 
-HugeGraphServer启动时会连接后端存储并尝试检查后端存储版本号，如果未初始化后端或者后端已初始化但版本不匹配时（旧版本数据），HugeGraphServer会启动失败，并给出错误信息。
+HugeGraphServer 启动时会连接后端存储并尝试检查后端存储版本号，如果未初始化后端或者后端已初始化但版本不匹配时（旧版本数据），HugeGraphServer 会启动失败，并给出错误信息。
 
-如果需要外部访问HugeGraphServer，请修改`rest-server.properties`的`restserver.url`配置项
-（默认为`http://127.0.0.1:8080`），修改成机器名或IP地址。
+如果需要外部访问 HugeGraphServer，请修改 `rest-server.properties` 的 `restserver.url` 配置项（默认为 `http://127.0.0.1:8080`），修改成机器名或 IP 地址。
 
 由于各种后端所需的配置（hugegraph.properties）及启动步骤略有不同，下面逐一对各后端的配置及启动做介绍。
 
@@ -144,7 +144,7 @@ backend=memory
 serializer=text
 ```
 
-> Memory后端的数据是保存在内存中无法持久化的，不需要初始化后端，这也是唯一一个不需要初始化的后端。
+> Memory 后端的数据是保存在内存中无法持久化的，不需要初始化后端，这也是唯一一个不需要初始化的后端。
 
 启动 server
 
@@ -158,7 +158,7 @@ Connecting to HugeGraphServer (http://127.0.0.1:8080/graphs)....OK
 
 #### 5.2 RocksDB
 
-> RocksDB是一个嵌入式的数据库，不需要手动安装部署, 要求 GCC 版本 >= 4.3.0（GLIBCXX_3.4.10），如不满足，需要提前升级 GCC
+> RocksDB 是一个嵌入式的数据库，不需要手动安装部署，要求 GCC 版本 >= 4.3.0（GLIBCXX_3.4.10），如不满足，需要提前升级 GCC
 
 修改 hugegraph.properties
 
@@ -176,7 +176,7 @@ cd hugegraph-${version}
 bin/init-store.sh
 ```
 
-启动server
+启动 server
 
 ```bash
 bin/start-hugegraph.sh
@@ -230,7 +230,7 @@ Initing HugeGraph Store...
 2017-12-01 11:27:00 10413 [pool-3-thread-1] [INFO ] com.baidu.hugegraph.backend.Transaction [] - Clear cache on event 'store.init'
 ```
 
-启动server
+启动 server
 
 ```bash
 bin/start-hugegraph.sh
@@ -260,7 +260,7 @@ cassandra.password=
 #cassandra.keyspace.replication=3
 ```
 
-由于 scylladb 数据库本身就是基于 cassandra 的"优化版"，如果用户未安装 scylladb ，也可以直接使用 cassandra 作为后端存储，只需要把 backend 和 serializer 修改为 scylladb，host 和 post 指向 cassandra 集群的 seeds 和 port 即可，但是并不建议这样做，这样发挥不出 scylladb 本身的优势了。
+由于 scylladb 数据库本身就是基于 cassandra 的"优化版"，如果用户未安装 scylladb，也可以直接使用 cassandra 作为后端存储，只需要把 backend 和 serializer 修改为 scylladb，host 和 post 指向 cassandra 集群的 seeds 和 port 即可，但是并不建议这样做，这样发挥不出 scylladb 本身的优势了。
 
 初始化数据库（仅第一次启动时需要）
 
@@ -269,7 +269,7 @@ cd hugegraph-${version}
 bin/init-store.sh
 ```
 
-启动server
+启动 server
 
 ```bash
 bin/start-hugegraph.sh
@@ -304,7 +304,7 @@ cd hugegraph-${version}
 bin/init-store.sh
 ```
 
-启动server
+启动 server
 
 ```bash
 bin/start-hugegraph.sh
@@ -314,36 +314,36 @@ Connecting to HugeGraphServer (http://127.0.0.1:8080/graphs)....OK
 
 > 更多其它后端配置可参考[配置项介绍](/docs/config/config-option)
 
-### 6 访问Server
+### 6 访问 Server
 
 #### 6.1 服务启动状态校验
 
-`jps`查看服务进程
+`jps` 查看服务进程
 
 ```bash
 jps
 6475 HugeGraphServer
 ```
 
-`curl`请求`RESTfulAPI`
+`curl` 请求 RESTful API
 
 ```bash
 echo `curl -o /dev/null -s -w %{http_code} "http://localhost:8080/graphs/hugegraph/graph/vertices"`
 ```
 
-返回结果200，代表server启动正常
+返回结果 200，代表 server 启动正常
 
-#### 6.2 请求Server
+#### 6.2 请求 Server
 
-HugeGraphServer的RESTful API包括多种类型的资源，典型的包括graph、schema、gremlin、traverser和task，
+HugeGraphServer 的 RESTful API 包括多种类型的资源，典型的包括 graph、schema、gremlin、traverser 和 task
 
-- `graph`包含`vertices`、`edges`
-- `schema` 包含`vertexlabels`、 `propertykeys`、 `edgelabels`、`indexlabels`
-- `gremlin`包含各种`Gremlin`语句，如`g.v()`，可以同步或者异步执行
-- `traverser`包含各种高级查询，包括最短路径、交叉点、N步可达邻居等
-- `task`包含异步任务的查询和删除
+- `graph` 包含 `vertices`、`edges`
+- `schema` 包含 `vertexlabels`、`propertykeys`、`edgelabels`、`indexlabels`
+- `gremlin` 包含各种 `Gremlin` 语句，如 `g.v()`，可以同步或者异步执行
+- `traverser` 包含各种高级查询，包括最短路径、交叉点、N 步可达邻居等
+- `task` 包含异步任务的查询和删除
 
-##### 6.2.1 获取`hugegraph`的顶点及相关属性
+##### 6.2.1 获取 `hugegraph` 的顶点及相关属性
 
 ```bash
 curl http://localhost:8080/graphs/hugegraph/graph/vertices 
@@ -351,14 +351,13 @@ curl http://localhost:8080/graphs/hugegraph/graph/vertices
 
 _说明_
 
-1. 由于图的点和边很多，对于 list 型的请求，比如获取所有顶点，获取所有边等，Server 会将数据压缩再返回，
-所以使用 curl 时得到一堆乱码，可以重定向至 `gunzip` 进行解压。推荐使用 Chrome 浏览器 + Restlet 插件发送 HTTP 请求进行测试。
+1. 由于图的点和边很多，对于 list 型的请求，比如获取所有顶点，获取所有边等，Server 会将数据压缩再返回，所以使用 curl 时得到一堆乱码，可以重定向至 `gunzip` 进行解压。推荐使用 Chrome 浏览器 + Restlet 插件发送 HTTP 请求进行测试。
 
     ```
     curl "http://localhost:8080/graphs/hugegraph/graph/vertices" | gunzip
     ```
 
-2. 当前HugeGraphServer的默认配置只能是本机访问，可以修改配置，使其能在其他机器访问。
+2. 当前 HugeGraphServer 的默认配置只能是本机访问，可以修改配置，使其能在其他机器访问。
 
     ```
     vim conf/rest-server.properties
@@ -420,9 +419,9 @@ _说明_
 }
 ```
 
-详细的API请参考[RESTful-API](/docs/clients/restful-api)文档
+详细的 API 请参考 [RESTful-API](/docs/clients/restful-api) 文档
 
-### 7 停止Server
+### 7 停止 Server
 
 ```bash
 $cd hugegraph-${version}
@@ -431,7 +430,7 @@ $bin/stop-hugegraph.sh
 
 ### 8 使用 IntelliJ IDEA 调试 Server
 
-请参考[如何在 IDEA 中搭建 HugeGraph-Server 开发环境](/docs/contribution-guidelines/hugegraph-server-idea-setup)
+请参考[在 IDEA 中配置 Server 开发环境](/docs/contribution-guidelines/hugegraph-server-idea-setup)
 
 ### 9 在启动 Server 时创建示例图
 
@@ -477,7 +476,7 @@ schema = graph.schema()
 
 并且使用 RESTful API 请求 `HugeGraphServer` 得到如下结果：
 
-```json
+```javascript
 > curl "http://localhost:8080/graphs/hugegraph/graph/vertices" | gunzip
 
   % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current

--- a/content/en/docs/clients/gremlin-console.md
+++ b/content/en/docs/clients/gremlin-console.md
@@ -6,8 +6,8 @@ weight: 3
 
 Gremlin-Console is an interactive client developed by TinkerPop. Users can use this client to perform various operations on Graph. There are two main usage modes:
 
-- Stand-alone offline mode;
-- Client/Server mode;
+- Stand-alone offline mode
+- Client/Server mode
 
 ### 1 Stand-alone offline mode
 
@@ -15,103 +15,106 @@ Since the lib directory already contains the HugeCore jar package, and HugeGraph
 
 This mode is convenient for users to get started quickly, but it is not suitable for scenarios where a large amount of data is inserted and queried. Here is an example:
 
-There is a sample script in the script directory：example.groovy
+There is a sample script in the script directory `example.groovy`:
 
 ```groovy
-import com.baidu.hugegraph.HugeFactory
-import com.baidu.hugegraph.dist.RegisterUtil
+import org.apache.hugegraph.HugeFactory
+import org.apache.hugegraph.backend.id.IdGenerator
+import org.apache.hugegraph.dist.RegisterUtil
+import org.apache.hugegraph.type.define.NodeRole
 import org.apache.tinkerpop.gremlin.structure.T
 
-RegisterUtil.registerCassandra();
-RegisterUtil.registerScyllaDB();
+RegisterUtil.registerRocksDB()
 
-conf = "conf/hugegraph.properties"
-graph = HugeFactory.open(conf);
-schema = graph.schema();
+conf = "conf/graphs/hugegraph.properties"
+graph = HugeFactory.open(conf)
+graph.serverStarted(IdGenerator.of("server-tinkerpop"), NodeRole.MASTER)
+schema = graph.schema()
 
-schema.propertyKey("name").asText().ifNotExist().create();
-schema.propertyKey("age").asInt().ifNotExist().create();
-schema.propertyKey("city").asText().ifNotExist().create();
-schema.propertyKey("weight").asDouble().ifNotExist().create();
-schema.propertyKey("lang").asText().ifNotExist().create();
-schema.propertyKey("date").asText().ifNotExist().create();
-schema.propertyKey("price").asInt().ifNotExist().create();
+schema.propertyKey("name").asText().ifNotExist().create()
+schema.propertyKey("age").asInt().ifNotExist().create()
+schema.propertyKey("city").asText().ifNotExist().create()
+schema.propertyKey("weight").asDouble().ifNotExist().create()
+schema.propertyKey("lang").asText().ifNotExist().create()
+schema.propertyKey("date").asText().ifNotExist().create()
+schema.propertyKey("price").asInt().ifNotExist().create()
 
-schema.vertexLabel("person").properties("name", "age", "city").primaryKeys("name").ifNotExist().create();
-schema.vertexLabel("software").properties("name", "lang", "price").primaryKeys("name").ifNotExist().create();
-schema.indexLabel("personByName").onV("person").by("name").secondary().ifNotExist().create();
-schema.indexLabel("personByCity").onV("person").by("city").secondary().ifNotExist().create();
-schema.indexLabel("personByAgeAndCity").onV("person").by("age", "city").secondary().ifNotExist().create();
-schema.indexLabel("softwareByPrice").onV("software").by("price").range().ifNotExist().create();
-schema.edgeLabel("knows").sourceLabel("person").targetLabel("person").properties("date", "weight").ifNotExist().create();
-schema.edgeLabel("created").sourceLabel("person").targetLabel("software").properties("date", "weight").ifNotExist().create();
-schema.indexLabel("createdByDate").onE("created").by("date").secondary().ifNotExist().create();
-schema.indexLabel("createdByWeight").onE("created").by("weight").range().ifNotExist().create();
-schema.indexLabel("knowsByWeight").onE("knows").by("weight").range().ifNotExist().create();
+schema.vertexLabel("person").properties("name", "age", "city").primaryKeys("name").ifNotExist().create()
+schema.vertexLabel("software").properties("name", "lang", "price").primaryKeys("name").ifNotExist().create()
+schema.indexLabel("personByCity").onV("person").by("city").secondary().ifNotExist().create()
+schema.indexLabel("personByAgeAndCity").onV("person").by("age", "city").secondary().ifNotExist().create()
+schema.indexLabel("softwareByPrice").onV("software").by("price").range().ifNotExist().create()
+schema.edgeLabel("knows").sourceLabel("person").targetLabel("person").properties("date", "weight").ifNotExist().create()
+schema.edgeLabel("created").sourceLabel("person").targetLabel("software").properties("date", "weight").ifNotExist().create()
+schema.indexLabel("createdByDate").onE("created").by("date").secondary().ifNotExist().create()
+schema.indexLabel("createdByWeight").onE("created").by("weight").range().ifNotExist().create()
+schema.indexLabel("knowsByWeight").onE("knows").by("weight").range().ifNotExist().create()
 
-marko = graph.addVertex(T.label, "person", "name", "marko", "age", 29, "city", "Beijing");
-vadas = graph.addVertex(T.label, "person", "name", "vadas", "age", 27, "city", "Hongkong");
-lop = graph.addVertex(T.label, "software", "name", "lop", "lang", "java", "price", 328);
-josh = graph.addVertex(T.label, "person", "name", "josh", "age", 32, "city", "Beijing");
-ripple = graph.addVertex(T.label, "software", "name", "ripple", "lang", "java", "price", 199);
-peter = graph.addVertex(T.label, "person", "name", "peter", "age", 35, "city", "Shanghai");
+marko = graph.addVertex(T.label, "person", "name", "marko", "age", 29, "city", "Beijing")
+vadas = graph.addVertex(T.label, "person", "name", "vadas", "age", 27, "city", "Hongkong")
+lop = graph.addVertex(T.label, "software", "name", "lop", "lang", "java", "price", 328)
+josh = graph.addVertex(T.label, "person", "name", "josh", "age", 32, "city", "Beijing")
+ripple = graph.addVertex(T.label, "software", "name", "ripple", "lang", "java", "price", 199)
+peter = graph.addVertex(T.label, "person", "name", "peter", "age", 35, "city", "Shanghai")
 
-marko.addEdge("knows", vadas, "date", "20160110", "weight", 0.5);
-marko.addEdge("knows", josh, "date", "20130220", "weight", 1.0);
-marko.addEdge("created", lop, "date", "20171210", "weight", 0.4);
-josh.addEdge("created", lop, "date", "20091111", "weight", 0.4);
-josh.addEdge("created", ripple, "date", "20171210", "weight", 1.0);
-peter.addEdge("created", lop, "date", "20170324", "weight", 0.2);
+marko.addEdge("knows", vadas, "date", "20160110", "weight", 0.5)
+marko.addEdge("knows", josh, "date", "20130220", "weight", 1.0)
+marko.addEdge("created", lop, "date", "20171210", "weight", 0.4)
+josh.addEdge("created", lop, "date", "20091111", "weight", 0.4)
+josh.addEdge("created", ripple, "date", "20171210", "weight", 1.0)
+peter.addEdge("created", lop, "date", "20170324", "weight", 0.2)
 
-graph.tx().commit();
+graph.tx().commit()
 
-g = graph.traversal();
+g = graph.traversal()
 
-System.out.println(">>>> query all vertices: size=" + g.V().toList().size());
-System.out.println(">>>> query all edges: size=" + g.E().toList().size());
+System.out.println(">>>> query all vertices: size=" + g.V().toList().size())
+System.out.println(">>>> query all edges: size=" + g.E().toList().size())
 ```
 
 In fact, this groovy script is almost Java code, the only difference is that the variable definition can be written without the type declaration, and the semicolon at the end of each line can be removed.
 
-> `g.V()` is to get all the vertices, `g.E()` is to get all the edges, `toList()` is to store the result in a List, refer to[TinkerPop Terminal Steps](http://tinkerpop.apache.org/docs/current/reference/#terminal-steps)。
+> `g.V()` is to get all the vertices, `g.E()` is to get all the edges, `toList()` is to store the result in a List, refer to [TinkerPop Terminal Steps](http://tinkerpop.apache.org/docs/current/reference/#terminal-steps)。
 
 Enter the gremlin-console below and pass in the script to execute it:
 
 ```bash
-bin/gremlin-console.sh scripts/example.groovy
-objc[5038]: Class JavaLaunchHelper is implemented in both /Library/Java/JavaVirtualMachines/jdk1.8.0_121.jdk/Contents/Home/bin/java (0x10137a4c0) and /Library/Java/JavaVirtualMachines/jdk1.8.0_121.jdk/Contents/Home/jre/lib/libinstrument.dylib (0x102bbb4e0). One of the two will be used. Which one is undefined.
+> ./bin/gremlin-console.sh -- -i scripts/example.groovy
 
          \,,,/
          (o o)
 -----oOOo-(3)-oOOo-----
-plugin activated: com.baidu.hugegraph
+plugin activated: HugeGraph
 plugin activated: tinkerpop.server
 plugin activated: tinkerpop.utilities
 plugin activated: tinkerpop.tinkergraph
-2018-01-15 14:36:19 7516  [main] [WARN ] com.baidu.hugegraph.config.HugeConfig [] - The config option 'rocksdb.data_path' is redundant, please ensure it has been registered
-2018-01-15 14:36:19 7523  [main] [WARN ] com.baidu.hugegraph.config.HugeConfig [] - The config option 'rocksdb.wal_path' is redundant, please ensure it has been registered
-2018-01-15 14:36:19 7604  [main] [INFO ] com.baidu.hugegraph.HugeGraph [] - Opening backend store 'cassandra' for graph 'hugegraph'
+main dict load finished, time elapsed 644 ms
+model load finished, time elapsed 35 ms.
 >>>> query all vertices: size=6
 >>>> query all edges: size=6
+gremlin> 
 ```
+
+> The `--` here will be parsed by getopts as the last option, allowing the subsequent options to be passed to Gremlin-Console for processing. `-i` represents `Execute the specified script and leave the console open on completion`. For more options, you can refer to the [source code](https://github.com/apache/tinkerpop/blob/3.5.1/gremlin-console/src/main/groovy/org/apache/tinkerpop/gremlin/console/Console.groovy#L483) of Gremlin-Console.
 
 As you can see, 6 vertices and 6 edges are inserted and queried. After entering the console, you can continue to enter groovy statements to operate on the graph:
 
 ```groovy
 gremlin> g.V()
-==>v[2:ripple]
-==>v[1:vadas]
-==>v[1:peter]
+==>v[2:lop]
 ==>v[1:josh]
 ==>v[1:marko]
-==>v[2:lop]
+==>v[1:peter]
+==>v[1:vadas]
+==>v[2:ripple]
 gremlin> g.E()
-==>e[S1:josh>2>>S2:ripple][1:josh-created->2:ripple]
-==>e[S1:marko>1>20160110>S1:vadas][1:marko-knows->1:vadas]
-==>e[S1:peter>2>>S2:lop][1:peter-created->2:lop]
 ==>e[S1:josh>2>>S2:lop][1:josh-created->2:lop]
-==>e[S1:marko>1>20130220>S1:josh][1:marko-knows->1:josh]
+==>e[S1:josh>2>>S2:ripple][1:josh-created->2:ripple]
+==>e[S1:marko>1>>S1:josh][1:marko-knows->1:josh]
+==>e[S1:marko>1>>S1:vadas][1:marko-knows->1:vadas]
 ==>e[S1:marko>2>>S2:lop][1:marko-created->2:lop]
+==>e[S1:peter>2>>S2:lop][1:peter-created->2:lop]
+gremlin> 
 ```
 
 For more Gremlin statements, please refer to [Tinkerpop Official Website](http://tinkerpop.apache.org/docs/current/reference/)
@@ -120,189 +123,83 @@ For more Gremlin statements, please refer to [Tinkerpop Official Website](http:/
 
 Because Gremlin-Console can only connect to HugeGraph-Server through WebSocket, HugeGraph-Server provides HTTP connections by default, so modify the configuration of gremlin-server first.
 
-*Note: After changing the connection method to WebSocket, HugeGraph-Client, HugeGraph-Loader, HugeGraph-Studio and other supporting tools cannot be used.*
+*NOTE: After changing the connection method to WebSocket, HugeGraph-Client, HugeGraph-Loader, HugeGraph-Hubble and other supporting tools cannot be used.*
 
 ```yaml
 # vim conf/gremlin-server.yaml
-host: 127.0.0.1
-port: 8182
-scriptEvaluationTimeout: 30000
-# If you want to start gremlin-server for gremlin-console(web-socket),
+# ......
+# If you want to start gremlin-server for gremlin-console (web-socket),
 # please change `HttpChannelizer` to `WebSocketChannelizer` or comment this line.
 channelizer: org.apache.tinkerpop.gremlin.server.channel.HttpChannelizer
-graphs: {
-  hugegraph: conf/hugegraph.properties,
-  hugegraph1: conf/hugegraph1.properties
-}
-plugins:
-  - com.baidu.hugegraph
-scriptEngines: {
-  gremlin-groovy: {
-    imports: [java.lang.Math],
-    staticImports: [java.lang.Math.PI],
-    scripts: [scripts/empty-sample.groovy]
-  }
-}
-serializers:
-  - { className: org.apache.tinkerpop.gremlin.driver.ser.GryoLiteMessageSerializerV1d0,
-      config: {
-        serializeResultToString: false,
-        ioRegistries: [com.baidu.hugegraph.io.HugeGraphIoRegistry]
-      }
-    }
-  - { className: org.apache.tinkerpop.gremlin.driver.ser.GryoMessageSerializerV1d0,
-      config: {
-        serializeResultToString: true,
-        ioRegistries: [com.baidu.hugegraph.io.HugeGraphIoRegistry]
-      }
-    }
-  - { className: org.apache.tinkerpop.gremlin.driver.ser.GraphSONMessageSerializerGremlinV1d0,
-      config: {
-        serializeResultToString: false,
-        ioRegistries: [com.baidu.hugegraph.io.HugeGraphIoRegistry]
-      }
-    }
-  - { className: org.apache.tinkerpop.gremlin.driver.ser.GraphSONMessageSerializerGremlinV2d0,
-      config: {
-        serializeResultToString: false,
-        ioRegistries: [com.baidu.hugegraph.io.HugeGraphIoRegistry]
-      }
-    }
-  - { className: org.apache.tinkerpop.gremlin.driver.ser.GraphSONMessageSerializerV1d0,
-      config: {
-        serializeResultToString: false,
-        ioRegistries: [com.baidu.hugegraph.io.HugeGraphIoRegistry]
-      }
-    }
-metrics: {
-  consoleReporter: {enabled: false, interval: 180000},
-  csvReporter: {enabled: true, interval: 180000, fileName: /tmp/gremlin-server-metrics.csv},
-  jmxReporter: {enabled: false},
-  slf4jReporter: {enabled: false, interval: 180000},
-  gangliaReporter: {enabled: false, interval: 180000, addressingMode: MULTICAST},
-  graphiteReporter: {enabled: false, interval: 180000}
-}
-maxInitialLineLength: 4096
-maxHeaderSize: 8192
-maxChunkSize: 8192
-maxContentLength: 65536
-maxAccumulationBufferComponents: 1024
-resultIterationBatchSize: 64
-writeBufferLowWaterMark: 32768
-writeBufferHighWaterMark: 65536
-ssl: {
-  enabled: false
-}
+# ......
 ```
 
-Modify `channelizer: org.apache.tinkerpop.gremlin.server.channel.HttpChannelizer` to `channelizer: org.apache.tinkerpop.gremlin.server.channel.WebSocketChannelizer` or comment directly, and then follow the steps to start the Server.
+Modify `channelizer: org.apache.tinkerpop.gremlin.server.channel.HttpChannelizer` to `channelizer: org.apache.tinkerpop.gremlin.server.channel.WebSocketChannelizer` or comment directly, and then follow the [steps](/docs/quickstart/hugegraph-server/) to start the Server.
 
-Then enter gremlin-console
+Then enter gremlin-console:
 
 ```bash
-bin/gremlin-console.sh 
-objc[5761]: Class JavaLaunchHelper is implemented in both /Library/Java/JavaVirtualMachines/jdk1.8.0_121.jdk/Contents/Home/bin/java (0x10ec584c0) and /Library/Java/JavaVirtualMachines/jdk1.8.0_121.jdk/Contents/Home/jre/lib/libinstrument.dylib (0x10ecdc4e0). One of the two will be used. Which one is undefined.
+> ./bin/gremlin-console.sh
 
          \,,,/
          (o o)
 -----oOOo-(3)-oOOo-----
-plugin activated: com.baidu.hugegraph
+plugin activated: HugeGraph
 plugin activated: tinkerpop.server
 plugin activated: tinkerpop.utilities
 plugin activated: tinkerpop.tinkergraph
 ```
 
-To connect to the server, you need to specify the connection parameters in the configuration file, and there is a default remote.yaml file in the conf directory
+To connect to the server, you need to specify the connection parameters in the configuration file, and there is a default `remote.yaml` file in the conf directory
 
 ```yaml
 # cat conf/remote.yaml
 hosts: [localhost]
 port: 8182
 serializer: {
-  className: org.apache.tinkerpop.gremlin.driver.ser.GryoMessageSerializerV1d0,
+  className: org.apache.tinkerpop.gremlin.driver.ser.GraphSONMessageSerializerV1d0,
   config: {
-    serializeResultToString: true,
-    ioRegistries: [com.baidu.hugegraph.io.HugeGraphIoRegistry]
+    serializeResultToString: false,
+    ioRegistries: [org.apache.hugegraph.io.HugeGraphIoRegistry]
   }
 }
 ```
 
 ```groovy
 gremlin> :remote connect tinkerpop.server conf/remote.yaml
-2018-01-15 15:30:31 11528 [main] [INFO ] org.apache.tinkerpop.gremlin.driver.Connection [] - Created new connection for ws://localhost:8182/gremlin
-2018-01-15 15:30:31 11538 [main] [INFO ] org.apache.tinkerpop.gremlin.driver.Connection [] - Created new connection for ws://localhost:8182/gremlin
-2018-01-15 15:30:31 11538 [main] [INFO ] org.apache.tinkerpop.gremlin.driver.ConnectionPool [] - Opening connection pool on Host{address=localhost/127.0.0.1:8182, hostUri=ws://localhost:8182/gremlin} with core size of 2
 ==>Configured localhost/127.0.0.1:8182
 ```
 
-After the connection is successful, the only variables that can be used in the context of the console are two graph objects, hugegraph and hugegraph1 (configured in gremlin-server.yaml), and if you want to have more variables, you can add them in `scripts/empty-sample.groovy`, such as:
-
-```groovy
-import org.apache.tinkerpop.gremlin.server.util.LifeCycleHook
-
-// an init script that returns a Map allows explicit setting of global bindings.
-def globals = [:]
-
-// defines a sample LifeCycleHook that prints some output to the Gremlin Server console.
-// note that the name of the key in the "global" map is unimportant.
-globals << [hook: [
-        onStartUp : { ctx ->
-            ctx.logger.info("Executed once at startup of Gremlin Server.")
-        },
-        onShutDown: { ctx ->
-            ctx.logger.info("Executed once at shutdown of Gremlin Server.")
-        }
-] as LifeCycleHook]
-
-// define schema manger for hugegraph
-schema = hugegraph.schema()
-// define the default TraversalSource to bind queries to - this one will be named "g".
-g = hugegraph.traversal()
-```
-
-In this way, the two objects `schema` and `g` can be directly used in the console for metadata management and graph query.
-
-It doesn't matter if it is not defined, because all objects are available through the graph, for example:
+After a successful connection, if the sample graph `example.groovy` is imported during the startup of HugeGraphServer, you can directly perform queries in the console.
 
 ```groovy
 gremlin> :> hugegraph.traversal().V()
-==>v[2:ripple]
-==>v[1:vadas]
-==>v[1:peter]
-==>v[1:josh]
-==>v[1:marko]
-==>v[2:lop]
+==>[id:2:lop,label:software,type:vertex,properties:[name:lop,lang:java,price:328]]
+==>[id:1:josh,label:person,type:vertex,properties:[name:josh,age:32,city:Beijing]]
+==>[id:1:marko,label:person,type:vertex,properties:[name:marko,age:29,city:Beijing]]
+==>[id:1:peter,label:person,type:vertex,properties:[name:peter,age:35,city:Shanghai]]
+==>[id:1:vadas,label:person,type:vertex,properties:[name:vadas,age:27,city:Hongkong]]
+==>[id:2:ripple,label:software,type:vertex,properties:[name:ripple,lang:java,price:199]]
 ```
 
-In Client/Server mode, all operations related to Server must be added with `:> `, if not, it means local operation in the console.
+> NOTE: In Client/Server mode, all operations related to the Server should be prefixed with `:> `. If not added, it indicates local console operations.
 
-You can also put multiple statements in a string variable and send them to the server at once:
+You can also put multiple statements in a single string variable and send them to the Server at once:
 
 ```groovy
 gremlin> script = """
+......1> graph = hugegraph;
+......2> g = graph.traversal();
+......3> g.V().toList().size();
+......4> """
+==>
 graph = hugegraph;
-marko = graph.addVertex(T.label, "person", "name", "marko", "age", 29, "city", "Beijing");
-vadas = graph.addVertex(T.label, "person", "name", "vadas", "age", 27, "city", "Hongkong");
-lop = graph.addVertex(T.label, "software", "name", "lop", "lang", "java", "price", 328);
-josh = graph.addVertex(T.label, "person", "name", "josh", "age", 32, "city", "Beijing");
-ripple = graph.addVertex(T.label, "software", "name", "ripple", "lang", "java", "price", 199);
-peter = graph.addVertex(T.label, "person", "name", "peter", "age", 35, "city", "Shanghai");
-
-marko.addEdge("knows", vadas, "date", "20160110", "weight", 0.5);
-marko.addEdge("knows", josh, "date", "20130220", "weight", 1.0);
-marko.addEdge("created", lop, "date", "20171210", "weight", 0.4);
-josh.addEdge("created", lop, "date", "20091111", "weight", 0.4);
-josh.addEdge("created", ripple, "date", "20171210", "weight", 1.0);
-peter.addEdge("created", lop, "date", "20170324", "weight", 0.2);
-
-graph.tx().commit();
-
 g = graph.traversal();
 g.V().toList().size();
-"""
 
 gremlin> :> @script
 ==>6
+gremlin> 
 ```
 
 For more information on the use of gremlin-console, please refer to [Tinkerpop Official Website](http://tinkerpop.apache.org/docs/current/reference/)

--- a/content/en/docs/contribution-guidelines/hugegraph-server-idea-setup.md
+++ b/content/en/docs/contribution-guidelines/hugegraph-server-idea-setup.md
@@ -1,6 +1,6 @@
 ---
-title: "How to Set Up HugeGraph-Server Development Environment in IDEA"
-linkTitle: "How to Set Up HugeGraph-Server Development Environment in IDEA"
+title: "Setup Server in IDEA"
+linkTitle: "Setup Server in IDEA"
 weight: 4
 ---
 
@@ -102,6 +102,16 @@ curl "http://localhost:8080/graphs/hugegraph/graph/vertices" | gunzip
 
 At this point, you can view detailed variable information in the debugger.
 
+#### 5. Log4j2 Configuration
+
+By default, when running `InitStore` and `HugeGraphServer`, the Log4j2 configuration file path read is `hugegraph-dist/src/main/resources/log4j2.xml`, not `path-to-your-directory/conf/log4j2.xml`. This configuration file is read when starting HugeGraphServer using the **script**.
+
+To avoid maintaining two separate configuration files, you can modify the Log4j2 configuration file path when running and debugging HugeGraphServer in **IntelliJ IDEA**:
+
+1. Open the previously created `Application` configuration.
+2. Click on `Modify options` - `Add VM options`.
+3. Set the VM options to `-Dlog4j.configurationFile=conf/log4j2.xml`.
+
 ### Possible Issues
 
 #### java: package sun.misc does not exist
@@ -110,6 +120,10 @@ The reason may be that cross-compilation is triggered when using Java 11 to comp
 
 1. In IntelliJ IDEA, go to `Preferences/Settings` and find the `Java Compiler` panel. Then, disable the `--release` option (recommended).
 2. Set the Project SDK to 8.
+
+#### Unable to Print Location Information (%l) in Log4j2
+
+This is because Log4j2 uses asynchronous loggers. You can refer to the [official documentation](https://logging.apache.org/log4j/2.x/manual/layouts.html#LocationInformation) for configuration details.
 
 ### References
 

--- a/content/en/docs/quickstart/hugegraph-server.md
+++ b/content/en/docs/quickstart/hugegraph-server.md
@@ -6,9 +6,9 @@ weight: 1
 
 ### 1 HugeGraph-Server Overview
 
-`HugeGraph-Server` is the core part of the HugeGraph Project, contains submodules such as Core、Backend、API.
+`HugeGraph-Server` is the core part of the HugeGraph Project, contains submodules such as Core, Backend, API.
 
-The Core Module is an implementation of the Tinkerpop interface; The Backend module is used to save the graph data to the data store, currently supported backends include：Memory、Cassandra、ScyllaDB、RocksDB; The API Module provides HTTP Server, which converts Client's HTTP request into a call to Core Module.
+The Core Module is an implementation of the Tinkerpop interface; The Backend module is used to save the graph data to the data store, currently supported backends include: Memory, Cassandra, ScyllaDB, RocksDB; The API Module provides HTTP Server, which converts Client's HTTP request into a call to Core Module.
 
 > There will be two spellings HugeGraph-Server and HugeGraphServer in the document, and other modules are similar. There is no big difference in the meaning of these two ways of writing, which can be distinguished as follows: `HugeGraph-Server` represents the code of server-related components, `HugeGraphServer` represents the service process.
 
@@ -16,7 +16,7 @@ The Core Module is an implementation of the Tinkerpop interface; The Backend mod
 
 #### 2.1 Install Java11 (JDK 11)
 
-Consider use Java 11 to run `HugeGraph-Server`(also compatible with Java 8 now), and configure by yourself.
+Consider use Java 11 to run `HugeGraph-Server` (also compatible with Java 8 now), and configure by yourself.
 
 **Be sure to execute the `java -version` command to check the jdk version before reading**
 
@@ -35,7 +35,7 @@ There are three ways to deploy HugeGraph-Server components:
 
 #### 3.1 One-click deployment
 
-`HugeGraph-Tools` provides a command-line tool for one-click deployment, users can use this tool to quickly download、decompress、configure and start `HugeGraphServer` and `HugeGraph-Hubble` with one click.
+`HugeGraph-Tools` provides a command-line tool for one-click deployment, users can use this tool to quickly download, decompress, configure and start `HugeGraphServer` and `HugeGraph-Hubble` with one click.
 
 Of course, you should download the tarball of `HugeGraph-Toolchain` first.
 
@@ -49,7 +49,7 @@ tar zxf *hugegraph-*.tar.gz
 cd *hugegraph*/*tool* 
 ```
 
-> note：${version} is the version, The latest version can refer to [Download Page](/docs/download/download), or click the link to download directly from the Download page
+> note: `${version}` is the version, The latest version can refer to [Download Page](/docs/download/download), or click the link to download directly from the Download page
 
 The general entry script for HugeGraph-Tools is `bin/hugegraph`, Users can use the `help` command to view its usage, here only the commands for one-click deployment are introduced.
 
@@ -376,7 +376,7 @@ _explanation_
     restserver.url=http://0.0.0.0:8080
     ```
 
-response body：
+response body:
 
 ```javasript
 {
@@ -441,4 +441,51 @@ $bin/stop-hugegraph.sh
 
 ### 8 Debug Server with IntelliJ IDEA
 
-Please refer to [How to Set Up HugeGraph-Server Development Environment in IDEA](/docs/contribution-guidelines/hugegraph-server-idea-setup)
+Please refer to [Setup Server in IDEA](/docs/contribution-guidelines/hugegraph-server-idea-setup)
+
+### 9 Create Sample Graph on Server Startup
+
+Modify `conf/gremlin-server.yaml` and change `empty-sample.groovy` to `example.groovy`:
+
+```yaml
+org.apache.tinkerpop.gremlin.jsr223.ScriptFileGremlinPlugin: {
+    files: [scripts/example.groovy]
+}
+```
+
+Modify `scripts/example.groovy` as follows:
+
+```groovy
+conf = "conf/graphs/hugegraph.properties"
+graph = HugeFactory.open(conf)
+schema = graph.schema()
+```
+
+Afterwards, start the HugeGraph-Server using the script. If logs similar to the following are printed:
+
+```java
+2023-06-10 19:41:14 [main] [INFO] o.a.h.d.HugeGremlinServer [org.apache.hugegraph.dist.HugeGremlinServer.start(HugeGremlinServer.java:38)] - 3.5.1
+         \,,,/
+         (o o)
+-----oOOo-(3)-oOOo-----
+
+2023-06-10 19:41:14 [main] [INFO] o.a.h.u.ConfigUtil [org.apache.hugegraph.util.ConfigUtil.scanGraphsDir(ConfigUtil.java:88)] - Scanning option 'graphs' directory './conf/graphs'
+2023-06-10 19:41:14 [main] [INFO] o.a.h.d.HugeGremlinServer [org.apache.hugegraph.dist.HugeGremlinServer.start(HugeGremlinServer.java:52)] - Configuring Gremlin Server from /Users/dingyuchen/Desktop/hugegraph/apache-hugegraph-incubating-1.0.0/conf/gremlin-server.yaml
+>>>> query all vertices: size=6
+>>>> query all edges: size=6
+```
+
+And when using the RESTful API to request `HugeGraphServer`, you receive the following result:
+
+```javascript
+> curl "http://localhost:8080/graphs/hugegraph/graph/vertices" | gunzip
+
+  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
+                                 Dload  Upload   Total   Spent    Left  Speed
+100   222  100   222    0     0   3163      0 --:--:-- --:--:-- --:--:--  3964
+{"vertices":[{"id":"2:lop","label":"software","type":"vertex","properties":{"name":"lop","lang":"java","price":328}},{"id":"1:josh","label":"person","type":"vertex","properties":{"name":"josh","age":32,"city":"Beijing"}},{"id":"1:marko","label":"person","type":"vertex","properties":{"name":"marko","age":29,"city":"Beijing"}},{"id":"1:peter","label":"person","type":"vertex","properties":{"name":"peter","age":35,"city":"Shanghai"}},{"id":"1:vadas","label":"person","type":"vertex","properties":{"name":"vadas","age":27,"city":"Hongkong"}},{"id":"2:ripple","label":"software","type":"vertex","properties":{"name":"ripple","lang":"java","price":199}}]}
+```
+
+indicating the successful creation of the sample graph.
+
+> The process of creating sample graph on server startup is similar when using IntelliJ IDEA and will not be described further.


### PR DESCRIPTION
When starting HugeGraphServer with the script or with IDEA, the log4j configuration file being read is not the same file, which may cause some confusion for new developers. Therefore, I have added this part of the content to clarify it.

The gremlin-console guide is for PR https://github.com/apache/incubator-hugegraph/pull/2231

> EN doc will be synchronized later.