### PR TITLE
doc: update the community page

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -228,6 +228,31 @@ enable = false
 #  icon = "fab fa-stack-overflow"
 #  desc = "Practical questions and curated answers"
 # Developer relevant links. These will show up on right side of footer and in the community page if you have one.
+[[params.links.user]]
+  name ="Introduction"
+  url = "../docs/introduction/readme/"
+  icon = "fa fa-book"
+  desc = "Increase your understanding about the project"
+[[params.links.user]]
+  name ="Quick start"
+  url = "../docs/quickstart/hugegraph-server/"
+  icon = "fa fa-rocket"
+  desc = "Embark on your HugeGraph journey with a simple configuration"
+[[params.links.user]]
+  name ="Download"
+  url = "../docs/download/download/"
+  icon = "fa fa-download"
+  desc = "Explore the comprehensive details of the project"
+[[params.links.user]]
+  name ="Config"
+  url = "../docs/config/"
+  icon = "fa fa-cog"
+  desc = "Unleash your ideas through file configuration"
+[[params.links.user]]
+  name ="WeChat"
+  url = "https://github.com/apache/incubator-hugegraph#contact-us"
+  icon = "fa fa-comments"
+  desc = "Follow us on WeChat to get the latest news"
 [[params.links.developer]]
   name = "GitHub"
   url = "https://github.com/apache/incubator-hugegraph"
@@ -240,6 +265,6 @@ enable = false
 #  desc = "Chat with other project developers"
 [[params.links.developer]]
   name = "Developer mailing list"
-  url = "mailto:dev@hugegraph.apache.org"
+  url = "../docs/contribution-guidelines/subscribe/"
   icon = "fa fa-envelope"
   desc = "Discuss development issues around the project"


### PR DESCRIPTION
Subtask of #257, we could use a `TODO` tag to check the status: (**click** the button directly to mark it as done)

- [x] update the EN&CN community page
- [x] update the EN page with [README](https://github.com/apache/incubator-hugegraph-doc#subscribe-the-mailing-list) in  [subscriber](https://hugegraph.apache.org/docs/contribution-guidelines/subscribe/) page
- [x] update the EN page with [README](https://github.com/apache/incubator-hugegraph-doc#subscribe-the-mailing-list) in  [subscriber-cn](https://hugegraph.apache.org/cn/docs/contribution-guidelines/subscribe/) page & translation
- [x] enhance the content with `GPT/New Bing`
- [x] update the README info

After:
![image](https://github.com/apache/incubator-hugegraph-doc/assets/87920097/8b20d3af-1ddb-4037-80ec-1def8e50e73f)