### PR TITLE
chore: fix ssl mode & conf path

### DIFF
--- a/content/cn/docs/config/config-guide.md
+++ b/content/cn/docs/config/config-guide.md
@@ -253,7 +253,7 @@ cassandra.password=
 #jdbc.password=
 #jdbc.reconnect_max_times=3
 #jdbc.reconnect_interval=3
-#jdbc.sslmode=false
+#jdbc.ssl_mode=false
 
 # postgresql & cockroachdb backend config
 #jdbc.driver=org.postgresql.Driver

--- a/content/cn/docs/contribution-guidelines/hugegraph-server-idea-setup.md
+++ b/content/cn/docs/contribution-guidelines/hugegraph-server-idea-setup.md
@@ -48,7 +48,7 @@ rocksdb.wal_path=.
 
 - 在 `Use classpath of module` 中选择 `hugegraph-dist`
 - 将 `Main class` 设置为 `org.apache.hugegraph.cmd.InitStore`
-- 设置运行参数为 `conf/graphs/hugegraph.properties`，这里的路径是相对于工作路径的，需要将工作路径设置为 `path-to-your-directory`
+- 设置运行参数为 `conf/rest-server.properties`，这里的路径是相对于工作路径的，需要将工作路径设置为 `path-to-your-directory`
 
 配置完成后运行，如果运行成功，将会输出以下类似运行日志：
 

--- a/content/en/docs/config/config-guide.md
+++ b/content/en/docs/config/config-guide.md
@@ -251,7 +251,7 @@ cassandra.password=
 #jdbc.password=
 #jdbc.reconnect_max_times=3
 #jdbc.reconnect_interval=3
-#jdbc.sslmode=false
+#jdbc.ssl_mode=false
 
 # postgresql & cockroachdb backend config
 #jdbc.driver=org.postgresql.Driver

--- a/content/en/docs/contribution-guidelines/hugegraph-server-idea-setup.md
+++ b/content/en/docs/contribution-guidelines/hugegraph-server-idea-setup.md
@@ -48,7 +48,7 @@ Next, open the `Run/Debug Configurations` panel in IntelliJ IDEA and create a ne
 
 - Select `hugegraph-dist` as the `Use classpath of module`.
 - Set the `Main class` to `org.apache.hugegraph.cmd.InitStore`.
-- Set the program arguments to `conf/graphs/hugegraph.properties`. Note that the path here is relative to the working directory, so make sure to set the working directory to `path-to-your-directory`.
+- Set the program arguments to `conf/rest-server.properties`. Note that the path here is relative to the working directory, so make sure to set the working directory to `path-to-your-directory`.
 
 Once the configuration is completed, run it. If the execution is successful, the following runtime logs will be displayed:
 


### PR DESCRIPTION
1. unify `sslmode` -> `ssl_mode`
2. update conf file path according to https://github.com/apache/incubator-hugegraph/blob/master/hugegraph-dist/src/main/java/org/apache/hugegraph/cmd/InitStore.java#L60-L67