### PR TITLE
doc: update the outdated computer download link

### DIFF
--- a/content/cn/docs/quickstart/hugegraph-computer.md
+++ b/content/cn/docs/quickstart/hugegraph-computer.md
@@ -37,8 +37,7 @@ weight: 7
 
 ```bash
 wget https://downloads.apache.org/incubator/hugegraph/${version}/apache-hugegraph-computer-incubating-${version}.tar.gz
-tar zxvf apache-hugegraph-computer-incubating-${version}.tar.gz
-mv apache-hugegraph-computer-incubating-${version} hugegraph-computer
+tar zxvf apache-hugegraph-computer-incubating-${version}.tar.gz -C hugegraph-computer
 ```
 
 #### 2.2 Clone source code to compile and package

--- a/content/cn/docs/quickstart/hugegraph-computer.md
+++ b/content/cn/docs/quickstart/hugegraph-computer.md
@@ -36,8 +36,9 @@ weight: 7
 下载最新版本的 HugeGraph-Computer release 包：
 
 ```bash
-wget https://github.com/apache/hugegraph-computer/releases/download/v${version}/hugegraph-loader-${version}.tar.gz
-tar zxvf hugegraph-computer-${version}.tar.gz
+wget https://downloads.apache.org/incubator/hugegraph/${version}/apache-hugegraph-computer-incubating-${version}.tar.gz
+tar zxvf apache-hugegraph-computer-incubating-${version}.tar.gz
+mv apache-hugegraph-computer-incubating-${version} hugegraph-computer
 ```
 
 #### 2.2 Clone source code to compile and package
@@ -60,13 +61,13 @@ mvn clean package -DskipTests
 > 您可以使用 `-c` 参数指定配置文件, 更多computer 配置请看: [Computer Config Options](/docs/config/config-computer#computer-config-options)
 
 ```bash
-cd hugegraph-computer-${version}
+cd hugegraph-computer
 bin/start-computer.sh -d local -r master
 ```
 
 #### 2.4 启动 worker 节点
 
-```
+```bash
 bin/start-computer.sh -d local -r worker
 ```
 

--- a/content/en/docs/quickstart/hugegraph-computer.md
+++ b/content/en/docs/quickstart/hugegraph-computer.md
@@ -36,8 +36,9 @@ There are two ways to get HugeGraph-Computer:
 Download the latest version of the HugeGraph-Computer release package:
 
 ```bash
-wget https://github.com/apache/hugegraph-computer/releases/download/v${version}/hugegraph-loader-${version}.tar.gz
-tar zxvf hugegraph-computer-${version}.tar.gz
+wget https://downloads.apache.org/incubator/hugegraph/${version}/apache-hugegraph-computer-incubating-${version}.tar.gz
+tar zxvf apache-hugegraph-computer-incubating-${version}.tar.gz
+mv apache-hugegraph-computer-incubating-${version} hugegraph-computer
 ```
 
 #### 2.2 Clone source code to compile and package
@@ -60,13 +61,13 @@ mvn clean package -DskipTests
 > You can use `-c`  parameter specify the configuration file, more computer config please see:[Computer Config Options](/docs/config/config-computer#computer-config-options)
 
 ```bash
-cd hugegraph-computer-${version}
+cd hugegraph-computer
 bin/start-computer.sh -d local -r master
 ```
 
 #### 2.4 Start worker node
 
-```
+```bash
 bin/start-computer.sh -d local -r worker
 ```
 

--- a/content/en/docs/quickstart/hugegraph-computer.md
+++ b/content/en/docs/quickstart/hugegraph-computer.md
@@ -37,8 +37,7 @@ Download the latest version of the HugeGraph-Computer release package:
 
 ```bash
 wget https://downloads.apache.org/incubator/hugegraph/${version}/apache-hugegraph-computer-incubating-${version}.tar.gz
-tar zxvf apache-hugegraph-computer-incubating-${version}.tar.gz
-mv apache-hugegraph-computer-incubating-${version} hugegraph-computer
+tar zxvf apache-hugegraph-computer-incubating-${version}.tar.gz -C hugegraph-computer
 ```
 
 #### 2.2 Clone source code to compile and package


### PR DESCRIPTION
> fix of the issue https://github.com/apache/incubator-hugegraph-doc/issues/277
Fix the page: 
https://hugegraph.apache.org/cn/docs/quickstart/hugegraph-computer/  https://hugegraph.apache.org/docs/quickstart/hugegraph-computer/

update the outdated download link of computer

The Updated page looks like:
![en](https://github.com/apache/incubator-hugegraph-doc/assets/49650772/c5901c55-1376-4d7b-837f-48fe9da90b9b)

