### PR TITLE
Fix: add ASF category B validation and modify category X entries for validating HugeGraph 1.2.0 release

### DIFF
--- a/.github/workflows/validate-release.yml
+++ b/.github/workflows/validate-release.yml
@@ -97,7 +97,7 @@ jobs:
           cd dist/${{ inputs.release_version }} || exit
 
           ls -lh ./*.tar.gz
-          CATEGORY_X="GPL|LGPL|Sleepycat License|BSD-4-Clause|BCL|JSR-275|ASL|RSAL|QPL|SSPL|CPOL|NPL1|Creative Commons Non-Commercial"
+          CATEGORY_X="GPL|LGPL|Sleepycat License|BSD-4-Clause|BCL|JSR-275|Amazon Software License|RSAL|QPL|SSPL|CPOL|NPL1|Creative Commons Non-Commercial"
           CATEGORY_B="CDDL1|CPL|EPL|IPL|MPL|SPL|OSL-3.0|UnRAR License|Erlang Public License|OFL|Ubuntu Font License Version 1.0|IPA Font License Agreement v1.0|EPL2.0|CC-BY"
           for i in *src.tar.gz; do
             echo "$i"

--- a/.github/workflows/validate-release.yml
+++ b/.github/workflows/validate-release.yml
@@ -97,8 +97,8 @@ jobs:
           cd dist/${{ inputs.release_version }} || exit
 
           ls -lh ./*.tar.gz
-          CATEGORY_X="\bGPL\b|\bLGPL\b|Sleepycat License|BSD-4-Clause|\bBCL\b|JSR-275|Amazon Software License|\bRSAL\b|\bQPL\b|\bSSPL\b|\bCPOL\b|\bNPL1\b|Creative Commons Non-Commercial"
-          CATEGORY_B="\bCDDL1\b|\bCPL\b|\bEPL\b|\bIPL\b|\bMPL\b|\bSPL\b|OSL-3.0|UnRAR License|Erlang Public License|\bOFL\b|Ubuntu Font License Version 1.0|IPA Font License Agreement v1.0|EPL2.0|CC-BY"
+          CATEGORY_X="\bGPL|\bLGPL|Sleepycat License|BSD-4-Clause|\bBCL\b|JSR-275|Amazon Software License|\bRSAL\b|\bQPL\b|\bSSPL|\bCPOL|\bNPL1|Creative Commons Non-Commercial"
+          CATEGORY_B="\bCDDL1|\bCPL|\bEPL|\bIPL|\bMPL|\bSPL|OSL-3.0|UnRAR License|Erlang Public License|\bOFL\b|Ubuntu Font License Version 1.0|IPA Font License Agreement v1.0|EPL2.0|CC-BY"
           for i in *src.tar.gz; do
             echo "$i"
 
@@ -233,7 +233,7 @@ jobs:
       - name: 7. Validate Binary Packages
         run: |
           cd dist/${{ inputs.release_version }} || exit
-          CATEGORY_X="\bGPL\b|\bLGPL\b|Sleepycat License|BSD-4-Clause|\bBCL\b|JSR-275|Amazon Software License|\bRSAL\b|\bQPL\b|\bSSPL\b|\bCPOL\b|\bNPL1\b|Creative Commons Non-Commercial"
+          CATEGORY_X="\bGPL|\bLGPL|Sleepycat License|BSD-4-Clause|\bBCL\b|JSR-275|Amazon Software License|\bRSAL\b|\bQPL\b|\bSSPL|\bCPOL|\bNPL1|Creative Commons Non-Commercial"
           for i in *.tar.gz; do
             if [[ "$i" == *-src.tar.gz ]]; then
               # skip source packages

--- a/.github/workflows/validate-release.yml
+++ b/.github/workflows/validate-release.yml
@@ -97,8 +97,8 @@ jobs:
           cd dist/${{ inputs.release_version }} || exit
 
           ls -lh ./*.tar.gz
-          CATEGORY_X="\bGPL\b|\bLGPL\b|\bSleepycat License\b|\bBSD-4-Clause\b|\bBCL\b|\bJSR-275\b|\bAmazon Software License\b|\bRSAL\b|\bQPL\b|\bSSPL\b|\bCPOL\b|\bNPL1\b|\bCreative Commons Non-Commercial\b"
-          CATEGORY_B="\bCDDL1\b|\bCPL\b|\bEPL\b|\bIPL\b|\bMPL\b|\bSPL\b|\bOSL-3.0\b|\bUnRAR License\b|\bErlang Public License\b|\bOFL\b|\bUbuntu Font License Version 1.0\b|\bIPA Font License Agreement v1.0\b|\bEPL2.0\b|\bCC-BY\b"
+          CATEGORY_X="\bGPL\b|\bLGPL\b|Sleepycat License|BSD-4-Clause|\bBCL\b|JSR-275|Amazon Software License|\bRSAL\b|\bQPL\b|\bSSPL\b|\bCPOL\b|\bNPL1\b|Creative Commons Non-Commercial"
+          CATEGORY_B="\bCDDL1\b|\bCPL\b|\bEPL\b|\bIPL\b|\bMPL\b|\bSPL\b|OSL-3.0|UnRAR License|Erlang Public License|\bOFL\b|Ubuntu Font License Version 1.0|IPA Font License Agreement v1.0|EPL2.0|CC-BY"
           for i in *src.tar.gz; do
             echo "$i"
 
@@ -233,7 +233,7 @@ jobs:
       - name: 7. Validate Binary Packages
         run: |
           cd dist/${{ inputs.release_version }} || exit
-          CATEGORY_X="\bGPL\b|\bLGPL\b|\bSleepycat License\b|\bBSD-4-Clause\b|\bBCL\b|\bJSR-275\b|\bAmazon Software License\b|\bRSAL\b|\bQPL\b|\bSSPL\b|\bCPOL\b|\bNPL1\b|\bCreative Commons Non-Commercial\b"
+          CATEGORY_X="\bGPL\b|\bLGPL\b|Sleepycat License|BSD-4-Clause|\bBCL\b|JSR-275|Amazon Software License|\bRSAL\b|\bQPL\b|\bSSPL\b|\bCPOL\b|\bNPL1\b|Creative Commons Non-Commercial"
           for i in *.tar.gz; do
             if [[ "$i" == *-src.tar.gz ]]; then
               # skip source packages

--- a/.github/workflows/validate-release.yml
+++ b/.github/workflows/validate-release.yml
@@ -97,8 +97,8 @@ jobs:
           cd dist/${{ inputs.release_version }} || exit
 
           ls -lh ./*.tar.gz
-          CATEGORY_X="GPL|LGPL|Sleepycat License|BSD-4-Clause|BCL|JSR-275|Amazon Software License|RSAL|QPL|SSPL|CPOL|NPL1|Creative Commons Non-Commercial"
-          CATEGORY_B="CDDL1|CPL|EPL|IPL|MPL|SPL|OSL-3.0|UnRAR License|Erlang Public License|OFL|Ubuntu Font License Version 1.0|IPA Font License Agreement v1.0|EPL2.0|CC-BY"
+          CATEGORY_X=" GPL| LGPL|Sleepycat License|BSD-4-Clause| BCL|JSR-275|Amazon Software License| RSAL| QPL| SSPL| CPOL| NPL1|Creative Commons Non-Commercial"
+          CATEGORY_B=" CDDL1| CPL| EPL| IPL| MPL| SPL| OSL-3.0| UnRAR License|Erlang Public License| OFL|Ubuntu Font License Version 1.0|IPA Font License Agreement v1.0| EPL2.0| CC-BY"
           for i in *src.tar.gz; do
             echo "$i"
 
@@ -233,7 +233,7 @@ jobs:
       - name: 7. Validate Binary Packages
         run: |
           cd dist/${{ inputs.release_version }} || exit
-
+          CATEGORY_X=" GPL| LGPL|Sleepycat License|BSD-4-Clause| BCL|JSR-275|Amazon Software License| RSAL| QPL| SSPL| CPOL| NPL1|Creative Commons Non-Commercial"
           for i in *.tar.gz; do
             if [[ "$i" == *-src.tar.gz ]]; then
               # skip source packages

--- a/.github/workflows/validate-release.yml
+++ b/.github/workflows/validate-release.yml
@@ -97,7 +97,7 @@ jobs:
           cd dist/${{ inputs.release_version }} || exit
 
           ls -lh ./*.tar.gz
-          CATEGORY_X="GPL|LGPL|Sleepycat License|BSD-4-Clause||BCL|JSR-275|ASL|RSAL|QPL|SSPL|CPOL|NPL1|Creative Commons Non-Commercial"
+          CATEGORY_X="GPL|LGPL|Sleepycat License|BSD-4-Clause|BCL|JSR-275|ASL|RSAL|QPL|SSPL|CPOL|NPL1|Creative Commons Non-Commercial"
           CATEGORY_B="CDDL1|CPL|EPL|IPL|MPL|SPL|OSL-3.0|UnRAR License|Erlang Public License|OFL|Ubuntu Font License Version 1.0|IPA Font License Agreement v1.0|EPL2.0|CC-BY"
           for i in *src.tar.gz; do
             echo "$i"

--- a/.github/workflows/validate-release.yml
+++ b/.github/workflows/validate-release.yml
@@ -97,8 +97,8 @@ jobs:
           cd dist/${{ inputs.release_version }} || exit
 
           ls -lh ./*.tar.gz
-          CATEGORY_X=" GPL| LGPL|Sleepycat License|BSD-4-Clause| BCL|JSR-275|Amazon Software License| RSAL| QPL| SSPL| CPOL| NPL1|Creative Commons Non-Commercial"
-          CATEGORY_B=" CDDL1| CPL| EPL| IPL| MPL| SPL| OSL-3.0| UnRAR License|Erlang Public License| OFL|Ubuntu Font License Version 1.0|IPA Font License Agreement v1.0| EPL2.0| CC-BY"
+          CATEGORY_X="\bGPL\b|\bLGPL\b|\bSleepycat License\b|\bBSD-4-Clause\b|\bBCL\b|\bJSR-275\b|\bAmazon Software License\b|\bRSAL\b|\bQPL\b|\bSSPL\b|\bCPOL\b|\bNPL1\b|\bCreative Commons Non-Commercial\b"
+          CATEGORY_B="\bCDDL1\b|\bCPL\b|\bEPL\b|\bIPL\b|\bMPL\b|\bSPL\b|\bOSL-3.0\b|\bUnRAR License\b|\bErlang Public License\b|\bOFL\b|\bUbuntu Font License Version 1.0\b|\bIPA Font License Agreement v1.0\b|\bEPL2.0\b|\bCC-BY\b"
           for i in *src.tar.gz; do
             echo "$i"
 
@@ -233,7 +233,7 @@ jobs:
       - name: 7. Validate Binary Packages
         run: |
           cd dist/${{ inputs.release_version }} || exit
-          CATEGORY_X=" GPL| LGPL|Sleepycat License|BSD-4-Clause| BCL|JSR-275|Amazon Software License| RSAL| QPL| SSPL| CPOL| NPL1|Creative Commons Non-Commercial"
+          CATEGORY_X="\bGPL\b|\bLGPL\b|\bSleepycat License\b|\bBSD-4-Clause\b|\bBCL\b|\bJSR-275\b|\bAmazon Software License\b|\bRSAL\b|\bQPL\b|\bSSPL\b|\bCPOL\b|\bNPL1\b|\bCreative Commons Non-Commercial\b"
           for i in *.tar.gz; do
             if [[ "$i" == *-src.tar.gz ]]; then
               # skip source packages

--- a/.github/workflows/validate-release.yml
+++ b/.github/workflows/validate-release.yml
@@ -97,6 +97,8 @@ jobs:
           cd dist/${{ inputs.release_version }} || exit
 
           ls -lh ./*.tar.gz
+          CATEGORY_X="GPL|LGPL|Sleepycat License|BSD-4-Clause||BCL|JSR-275|ASL|RSAL|QPL|SSPL|CPOL|NPL1|Creative Commons Non-Commercial"
+          CATEGORY_B="CDDL1|CPL|EPL|IPL|MPL|SPL|OSL-3.0|UnRAR License|Erlang Public License|OFL|Ubuntu Font License Version 1.0|IPA Font License Agreement v1.0|EPL2.0|CC-BY"
           for i in *src.tar.gz; do
             echo "$i"
 
@@ -120,15 +122,21 @@ jobs:
                 echo "The package should include DISCLAIMER file" && exit 1
             fi
 
-            # 4.3 ensure doesn't contains *GPL/BCL/JSR-275/RSAL/QPL/SSPL/CPOL/NPL1.*/CC-BY 
-            #     dependency in LICENSE and NOTICE file 
-            COUNT=$(grep -E "GPL|BCL|JSR-275|RSAL|QPL|SSPL|CPOL|NPL1|CC-BY" LICENSE NOTICE | wc -l)
+            # 4.3: ensure doesn't contains ASF CATEGORY X License dependencies in LICENSE and NOTICE files
+            COUNT=$(grep -E $CATEGORY_X LICENSE NOTICE | wc -l)
             if [[ $COUNT -ne 0 ]]; then
-              grep -E "GPL|BCL|JSR-275|RSAL|QPL|SSPL|CPOL|NPL1.0|CC-BY" LICENSE NOTICE
-              echo "The package shouldn't include GPL* invalid dependency, but get $COUNT" && exit 1
+              grep -E "$CATEGORY_X" LICENSE NOTICE
+              echo "The package $i shouldn't include invalid ASF category X dependencies, but get $COUNT" && exit 1
+            fi
+          
+            # 4.4: ensure doesn't contains ASF CATEGORY B License dependencies in LICENSE and NOTICE files
+            COUNT=$(grep -E $CATEGORY_B LICENSE NOTICE | wc -l)
+            if [[ $COUNT -ne 0 ]]; then
+              grep -E "$CATEGORY_B" LICENSE NOTICE
+              echo "The package $i shouldn't include invalid ASF category B dependencies, but get $COUNT" && exit 1
             fi
 
-            # 4.4 ensure doesn't contains empty directory or file
+            # 4.5 ensure doesn't contains empty directory or file
             find . -type d -empty | while read -r EMPTY_DIR; do
               find . -type d -empty
               echo "The package $i shouldn't include empty directory: $EMPTY_DIR is empty" && exit 1
@@ -138,13 +146,13 @@ jobs:
               echo "The package $i shouldn't include empty file: $EMPTY_FILE is empty" && exit 1
             done
 
-            # 4.5 ensure any file should less than 800kb
+            # 4.6 ensure any file should less than 800kb
             find . -type f -size +800k | while read -r FILE; do
               find . -type f -size +800k
               echo "The package $i shouldn't include file larger than 800kb: $FILE is larger than 800kb" && exit 1
             done
 
-            # 4.6: ensure all binary files are documented in LICENSE
+            # 4.7: ensure all binary files are documented in LICENSE
             find . -type f | perl -lne 'print if -B' | while read -r BINARY_FILE; do
               FILE_NAME=$(basename "$BINARY_FILE")
               if grep -q "$FILE_NAME" LICENSE; then
@@ -154,13 +162,14 @@ jobs:
               fi
             done
 
-            # 4.7 test compile the packages
+            # 4.8 test compile the packages
             if [[ ${{ matrix.java_version }} == 8 && "$i" =~ "computer" ]]; then
               echo "skip computer module in java8"
               popd || exit
               continue
             fi
-            mvn package -DskipTests -ntp -e || exit
+            # TODO: consider using commands that are entirely consistent with building binary packages
+            mvn package -DskipTests -Papache-release -ntp -e || exit
             ls -lh
 
             popd || exit
@@ -257,12 +266,11 @@ jobs:
               echo "The package should include licenses dir" && exit 1
             fi
 
-            # 7.3 ensure doesn't contains *GPL/BCL/JSR-275/RSAL/QPL/SSPL/CPOL/NPL1.*/CC-BY 
-            #     dependency in LICENSE/NOTICE and licenses/* files 
-            COUNT=$(grep -rE "GPL|BCL|JSR-275|RSAL|QPL|SSPL|CPOL|NPL1|CC-BY" LICENSE NOTICE licenses | wc -l)
+            # 7.3: ensure doesn't contains ASF CATEGORY X License dependencies in LICENSE/NOTICE and licenses/* files
+            COUNT=$(grep -r -E $CATEGORY_X LICENSE NOTICE licenses | wc -l)
             if [[ $COUNT -ne 0 ]]; then
-              grep -r -E "GPL|BCL|JSR-275|RSAL|QPL|SSPL|CPQL|NPL1|CC-BY" LICENSE NOTICE licenses
-              echo "The package shouldn't include GPL* invalid dependency, but get $COUNT" && exit 1
+              grep -r -E "$CATEGORY_X" LICENSE NOTICE licenses
+              echo "The package $i shouldn't include invalid ASF category X dependencies, but get $COUNT" && exit 1
             fi
 
             # 7.4: ensure doesn't contains empty directory or file

--- a/dist/validate-release.sh
+++ b/dist/validate-release.sh
@@ -150,7 +150,8 @@ for i in *src.tar.gz; do
     popd || exit
     continue
   fi
-  mvn package -DskipTests -ntp -e || exit
+  # TODO: consider using commands that are entirely consistent with building binary packages
+  mvn package -DskipTests -Papache-release -ntp -e || exit
   ls -lh
 
   popd || exit

--- a/dist/validate-release.sh
+++ b/dist/validate-release.sh
@@ -78,8 +78,8 @@ done
 ####################################
 cd "$WORK_DIR"/dist/"$RELEASE_VERSION" || exit
 
-CATEGORY_X="\bGPL\b|\bLGPL\b|\bSleepycat License\b|\bBSD-4-Clause\b|\bBCL\b|\bJSR-275\b|\bAmazon Software License\b|\bRSAL\b|\bQPL\b|\bSSPL\b|\bCPOL\b|\bNPL1\b|\bCreative Commons Non-Commercial\b"
-CATEGORY_B="\bCDDL1\b|\bCPL\b|\bEPL\b|\bIPL\b|\bMPL\b|\bSPL\b|\bOSL-3.0\b|\bUnRAR License\b|\bErlang Public License\b|\bOFL\b|\bUbuntu Font License Version 1.0\b|\bIPA Font License Agreement v1.0\b|\bEPL2.0\b|\bCC-BY\b"
+CATEGORY_X="\bGPL\b|\bLGPL\b|Sleepycat License|BSD-4-Clause|\bBCL\b|JSR-275|Amazon Software License|\bRSAL\b|\bQPL\b|\bSSPL\b|\bCPOL\b|\bNPL1\b|Creative Commons Non-Commercial"
+CATEGORY_B="\bCDDL1\b|\bCPL\b|\bEPL\b|\bIPL\b|\bMPL\b|\bSPL\b|OSL-3.0|UnRAR License|Erlang Public License|\bOFL\b|Ubuntu Font License Version 1.0|IPA Font License Agreement v1.0|EPL2.0|CC-BY"
 ls -lh ./*.tar.gz
 for i in *src.tar.gz; do
   echo "$i"

--- a/dist/validate-release.sh
+++ b/dist/validate-release.sh
@@ -78,7 +78,7 @@ done
 ####################################
 cd "$WORK_DIR"/dist/"$RELEASE_VERSION" || exit
 
-CATEGORY_X="GPL|LGPL|Sleepycat License|BSD-4-Clause|BCL|JSR-275|ASL|RSAL|QPL|SSPL|CPOL|NPL1|Creative Commons Non-Commercial"
+CATEGORY_X="GPL|LGPL|Sleepycat License|BSD-4-Clause|BCL|JSR-275|Amazon Software License|RSAL|QPL|SSPL|CPOL|NPL1|Creative Commons Non-Commercial"
 CATEGORY_B="CDDL1|CPL|EPL|IPL|MPL|SPL|OSL-3.0|UnRAR License|Erlang Public License|OFL|Ubuntu Font License Version 1.0|IPA Font License Agreement v1.0|EPL2.0|CC-BY"
 ls -lh ./*.tar.gz
 for i in *src.tar.gz; do

--- a/dist/validate-release.sh
+++ b/dist/validate-release.sh
@@ -78,6 +78,8 @@ done
 ####################################
 cd "$WORK_DIR"/dist/"$RELEASE_VERSION" || exit
 
+CATEGORY_X="GPL|LGPL|Sleepycat License|BSD-4-Clause||BCL|JSR-275|ASL|RSAL|QPL|SSPL|CPOL|NPL1|Creative Commons Non-Commercial"
+CATEGORY_B="CDDL1|CPL|EPL|IPL|MPL|SPL|OSL-3.0|UnRAR License|Erlang Public License|OFL|Ubuntu Font License Version 1.0|IPA Font License Agreement v1.0|EPL2.0|CC-BY"
 ls -lh ./*.tar.gz
 for i in *src.tar.gz; do
   echo "$i"
@@ -102,19 +104,14 @@ for i in *src.tar.gz; do
     echo "The package $i should include DISCLAIMER file" && exit 1
   fi
 
-  # 4.3: ensure doesn't contains *GPL/BCL/JSR-275/RSAL/QPL/SSPL/CPOL/NPL1.*/CC-BY
-  #      dependency in LICENSE and NOTICE file
-  CATEGORY_X="GPL|BCL|JSR-275|RSAL|QPL|SSPL|CPOL|NPL1|CC-BY"
+  # 4.3: ensure doesn't contains ASF CATEGORY X License dependencies in LICENSE and NOTICE files
   COUNT=$(grep -E $CATEGORY_X LICENSE NOTICE | wc -l)
   if [[ $COUNT -ne 0 ]]; then
      grep -E $CATEGORY_X LICENSE NOTICE
      echo "The package $i shouldn't include invalid ASF category X dependencies, but get $COUNT" && exit 1
   fi
 
-  # 4.4: ensure doesn't contains *CDDL1/CPL/EPL/IPL/MPL/SPL/OSL-3.0/UnRAR License/Erlang Public License
-  # /OFL/Ubuntu Font License Version 1.0/IPA Font License Agreement v1.0/EPL2.0
-  #      dependency in LICENSE and NOTICE file
-  CATEGORY_B="CDDL1/CPL/EPL/IPL/MPL/SPL/OSL-3.0/UnRAR License/Erlang Public License/OFL/Ubuntu Font License Version 1.0/IPA Font License Agreement v1.0/EPL2.0"
+  # 4.4: ensure doesn't contains ASF CATEGORY B License dependencies in LICENSE and NOTICE files
   COUNT=$(grep -E $CATEGORY_B LICENSE NOTICE | wc -l)
   if [[ $COUNT -ne 0 ]]; then
      grep -E $CATEGORY_B LICENSE NOTICE
@@ -253,12 +250,11 @@ for i in *.tar.gz; do
     echo "The package $i should include licenses dir" && exit 1
   fi
 
-  # 7.3: ensure doesn't contains *GPL/BCL/JSR-275/RSAL/QPL/SSPL/CPOL/NPL1.*/CC-BY
-  #      dependency in LICENSE/NOTICE and licenses/* files
-  COUNT=$(grep -r -E "GPL|BCL|JSR-275|RSAL|QPL|SSPL|CPOL|NPL1|CC-BY" LICENSE NOTICE licenses | wc -l)
+  # 7.3: ensure doesn't contains ASF CATEGORY X License dependencies in LICENSE/NOTICE and licenses/* files
+  COUNT=$(grep -r -E $CATEGORY_X LICENSE NOTICE licenses | wc -l)
   if [[ $COUNT -ne 0 ]]; then
-    grep -r -E "GPL|BCL|JSR-275|RSAL|QPL|SSPL|CPQL|NPL1|CC-BY" LICENSE NOTICE licenses
-    echo "The package $i shouldn't include GPL* invalid dependency, but get $COUNT" && exit 1
+    grep -r -E $CATEGORY_X LICENSE NOTICE licenses
+    echo "The package $i shouldn't include invalid ASF category X dependencies, but get $COUNT" && exit 1
   fi
 
   # 7.4: ensure doesn't contains empty directory or file

--- a/dist/validate-release.sh
+++ b/dist/validate-release.sh
@@ -78,7 +78,7 @@ done
 ####################################
 cd "$WORK_DIR"/dist/"$RELEASE_VERSION" || exit
 
-CATEGORY_X="GPL|LGPL|Sleepycat License|BSD-4-Clause||BCL|JSR-275|ASL|RSAL|QPL|SSPL|CPOL|NPL1|Creative Commons Non-Commercial"
+CATEGORY_X="GPL|LGPL|Sleepycat License|BSD-4-Clause|BCL|JSR-275|ASL|RSAL|QPL|SSPL|CPOL|NPL1|Creative Commons Non-Commercial"
 CATEGORY_B="CDDL1|CPL|EPL|IPL|MPL|SPL|OSL-3.0|UnRAR License|Erlang Public License|OFL|Ubuntu Font License Version 1.0|IPA Font License Agreement v1.0|EPL2.0|CC-BY"
 ls -lh ./*.tar.gz
 for i in *src.tar.gz; do

--- a/dist/validate-release.sh
+++ b/dist/validate-release.sh
@@ -150,9 +150,7 @@ for i in *src.tar.gz; do
     popd || exit
     continue
   fi
-#  mvn package -DskipTests -ntp -e || exit
-  # TODO: consider using commands that are entirely consistent with building binary packages
-  mvn package -DskipTests -Papache-release -ntp -e || exit
+  mvn package -DskipTests -ntp -e || exit
   ls -lh
 
   popd || exit

--- a/dist/validate-release.sh
+++ b/dist/validate-release.sh
@@ -78,8 +78,8 @@ done
 ####################################
 cd "$WORK_DIR"/dist/"$RELEASE_VERSION" || exit
 
-CATEGORY_X="\bGPL\b|\bLGPL\b|Sleepycat License|BSD-4-Clause|\bBCL\b|JSR-275|Amazon Software License|\bRSAL\b|\bQPL\b|\bSSPL\b|\bCPOL\b|\bNPL1\b|Creative Commons Non-Commercial"
-CATEGORY_B="\bCDDL1\b|\bCPL\b|\bEPL\b|\bIPL\b|\bMPL\b|\bSPL\b|OSL-3.0|UnRAR License|Erlang Public License|\bOFL\b|Ubuntu Font License Version 1.0|IPA Font License Agreement v1.0|EPL2.0|CC-BY"
+CATEGORY_X="\bGPL|\bLGPL|Sleepycat License|BSD-4-Clause|\bBCL\b|JSR-275|Amazon Software License|\bRSAL\b|\bQPL\b|\bSSPL|\bCPOL|\bNPL1|Creative Commons Non-Commercial"
+CATEGORY_B="\bCDDL1|\bCPL|\bEPL|\bIPL|\bMPL|\bSPL|OSL-3.0|UnRAR License|Erlang Public License|\bOFL\b|Ubuntu Font License Version 1.0|IPA Font License Agreement v1.0|EPL2.0|CC-BY"
 ls -lh ./*.tar.gz
 for i in *src.tar.gz; do
   echo "$i"
@@ -279,7 +279,7 @@ cd "$WORK_DIR"/dist/"$RELEASE_VERSION" || exit
 
 pushd ./*hugegraph-incubating*"${RELEASE_VERSION}" || exit
 bin/init-store.sh || exit
-sleep 3
+sleep 30
 bin/start-hugegraph.sh || exit
 popd || exit
 

--- a/dist/validate-release.sh
+++ b/dist/validate-release.sh
@@ -104,13 +104,24 @@ for i in *src.tar.gz; do
 
   # 4.3: ensure doesn't contains *GPL/BCL/JSR-275/RSAL/QPL/SSPL/CPOL/NPL1.*/CC-BY
   #      dependency in LICENSE and NOTICE file
-  COUNT=$(grep -E "GPL|BCL|JSR-275|RSAL|QPL|SSPL|CPOL|NPL1|CC-BY" LICENSE NOTICE | wc -l)
+  CATEGORY_X="GPL|BCL|JSR-275|RSAL|QPL|SSPL|CPOL|NPL1|CC-BY"
+  COUNT=$(grep -E $CATEGORY_X LICENSE NOTICE | wc -l)
   if [[ $COUNT -ne 0 ]]; then
-     grep -E "GPL|BCL|JSR-275|RSAL|QPL|SSPL|CPOL|NPL1.0|CC-BY" LICENSE NOTICE
-     echo "The package $i shouldn't include GPL* invalid dependency, but get $COUNT" && exit 1
+     grep -E $CATEGORY_X LICENSE NOTICE
+     echo "The package $i shouldn't include invalid ASF category X dependencies, but get $COUNT" && exit 1
   fi
 
-  # 4.4: ensure doesn't contains empty directory or file
+  # 4.4: ensure doesn't contains *CDDL1/CPL/EPL/IPL/MPL/SPL/OSL-3.0/UnRAR License/Erlang Public License
+  # /OFL/Ubuntu Font License Version 1.0/IPA Font License Agreement v1.0/EPL2.0
+  #      dependency in LICENSE and NOTICE file
+  CATEGORY_B="CDDL1/CPL/EPL/IPL/MPL/SPL/OSL-3.0/UnRAR License/Erlang Public License/OFL/Ubuntu Font License Version 1.0/IPA Font License Agreement v1.0/EPL2.0"
+  COUNT=$(grep -E $CATEGORY_B LICENSE NOTICE | wc -l)
+  if [[ $COUNT -ne 0 ]]; then
+     grep -E $CATEGORY_B LICENSE NOTICE
+     echo "The package $i shouldn't include invalid ASF category B dependencies, but get $COUNT" && exit 1
+  fi
+
+  # 4.5: ensure doesn't contains empty directory or file
   find . -type d -empty | while read -r EMPTY_DIR; do
     find . -type d -empty
     echo "The package $i shouldn't include empty directory: $EMPTY_DIR is empty" && exit 1
@@ -120,13 +131,13 @@ for i in *src.tar.gz; do
     echo "The package $i shouldn't include empty file: $EMPTY_FILE is empty" && exit 1
   done
 
-  # 4.5: ensure any file should less than 800kb
+  # 4.6: ensure any file should less than 800kb
   find . -type f -size +800k | while read -r FILE; do
     find . -type f -size +800k
     echo "The package $i shouldn't include file larger than 800kb: $FILE is larger than 800kb" && exit 1
   done
 
-  # 4.6: ensure all binary files are documented in LICENSE
+  # 4.7: ensure all binary files are documented in LICENSE
   find . -type f | perl -lne 'print if -B' | while read -r BINARY_FILE; do
     FILE_NAME=$(basename "$BINARY_FILE")
     if grep -q "$FILE_NAME" LICENSE; then
@@ -136,7 +147,7 @@ for i in *src.tar.gz; do
     fi
   done
 
-  # 4.7: test compile the packages
+  # 4.8: test compile the packages
   if [[ $JAVA_VERSION == 8 && "$i" =~ "computer" ]]; then
     echo "skip computer module in java8"
     popd || exit

--- a/dist/validate-release.sh
+++ b/dist/validate-release.sh
@@ -78,8 +78,8 @@ done
 ####################################
 cd "$WORK_DIR"/dist/"$RELEASE_VERSION" || exit
 
-CATEGORY_X="GPL|LGPL|Sleepycat License|BSD-4-Clause|BCL|JSR-275|Amazon Software License|RSAL|QPL|SSPL|CPOL|NPL1|Creative Commons Non-Commercial"
-CATEGORY_B="CDDL1|CPL|EPL|IPL|MPL|SPL|OSL-3.0|UnRAR License|Erlang Public License|OFL|Ubuntu Font License Version 1.0|IPA Font License Agreement v1.0|EPL2.0|CC-BY"
+CATEGORY_X=" GPL| LGPL|Sleepycat License|BSD-4-Clause| BCL|JSR-275|Amazon Software License| RSAL| QPL| SSPL| CPOL| NPL1|Creative Commons Non-Commercial"
+CATEGORY_B=" CDDL1| CPL| EPL| IPL| MPL| SPL| OSL-3.0| UnRAR License|Erlang Public License| OFL|Ubuntu Font License Version 1.0|IPA Font License Agreement v1.0| EPL2.0| CC-BY"
 ls -lh ./*.tar.gz
 for i in *src.tar.gz; do
   echo "$i"

--- a/dist/validate-release.sh
+++ b/dist/validate-release.sh
@@ -107,14 +107,14 @@ for i in *src.tar.gz; do
   # 4.3: ensure doesn't contains ASF CATEGORY X License dependencies in LICENSE and NOTICE files
   COUNT=$(grep -E $CATEGORY_X LICENSE NOTICE | wc -l)
   if [[ $COUNT -ne 0 ]]; then
-     grep -E $CATEGORY_X LICENSE NOTICE
+     grep -E "$CATEGORY_X" LICENSE NOTICE
      echo "The package $i shouldn't include invalid ASF category X dependencies, but get $COUNT" && exit 1
   fi
 
   # 4.4: ensure doesn't contains ASF CATEGORY B License dependencies in LICENSE and NOTICE files
   COUNT=$(grep -E $CATEGORY_B LICENSE NOTICE | wc -l)
   if [[ $COUNT -ne 0 ]]; then
-     grep -E $CATEGORY_B LICENSE NOTICE
+     grep -E "$CATEGORY_B" LICENSE NOTICE
      echo "The package $i shouldn't include invalid ASF category B dependencies, but get $COUNT" && exit 1
   fi
 
@@ -150,7 +150,9 @@ for i in *src.tar.gz; do
     popd || exit
     continue
   fi
-  mvn package -DskipTests -ntp -e || exit
+#  mvn package -DskipTests -ntp -e || exit
+  # TODO: consider using commands that are entirely consistent with building binary packages
+  mvn package -DskipTests -Papache-release -ntp -e || exit
   ls -lh
 
   popd || exit
@@ -253,7 +255,7 @@ for i in *.tar.gz; do
   # 7.3: ensure doesn't contains ASF CATEGORY X License dependencies in LICENSE/NOTICE and licenses/* files
   COUNT=$(grep -r -E $CATEGORY_X LICENSE NOTICE licenses | wc -l)
   if [[ $COUNT -ne 0 ]]; then
-    grep -r -E $CATEGORY_X LICENSE NOTICE licenses
+    grep -r -E "$CATEGORY_X" LICENSE NOTICE licenses
     echo "The package $i shouldn't include invalid ASF category X dependencies, but get $COUNT" && exit 1
   fi
 

--- a/dist/validate-release.sh
+++ b/dist/validate-release.sh
@@ -78,8 +78,8 @@ done
 ####################################
 cd "$WORK_DIR"/dist/"$RELEASE_VERSION" || exit
 
-CATEGORY_X=" GPL| LGPL|Sleepycat License|BSD-4-Clause| BCL|JSR-275|Amazon Software License| RSAL| QPL| SSPL| CPOL| NPL1|Creative Commons Non-Commercial"
-CATEGORY_B=" CDDL1| CPL| EPL| IPL| MPL| SPL| OSL-3.0| UnRAR License|Erlang Public License| OFL|Ubuntu Font License Version 1.0|IPA Font License Agreement v1.0| EPL2.0| CC-BY"
+CATEGORY_X="\bGPL\b|\bLGPL\b|\bSleepycat License\b|\bBSD-4-Clause\b|\bBCL\b|\bJSR-275\b|\bAmazon Software License\b|\bRSAL\b|\bQPL\b|\bSSPL\b|\bCPOL\b|\bNPL1\b|\bCreative Commons Non-Commercial\b"
+CATEGORY_B="\bCDDL1\b|\bCPL\b|\bEPL\b|\bIPL\b|\bMPL\b|\bSPL\b|\bOSL-3.0\b|\bUnRAR License\b|\bErlang Public License\b|\bOFL\b|\bUbuntu Font License Version 1.0\b|\bIPA Font License Agreement v1.0\b|\bEPL2.0\b|\bCC-BY\b"
 ls -lh ./*.tar.gz
 for i in *src.tar.gz; do
   echo "$i"


### PR DESCRIPTION
This PR is a subtask of https://github.com/apache/incubator-hugegraph-doc/pull/307, and it includes the following changes:

1. Add [ASF category B license](https://www.apache.org/legal/resolved.html#category-b) validation
2. Modify some incorrect entries for existing category X license validation based on (https://www.apache.org/legal/resolved.html#category-b)