### PR TITLE
fix: double quotes to avoid spaces in grep for validating release

### DIFF
--- a/.github/workflows/validate-release.yml
+++ b/.github/workflows/validate-release.yml
@@ -123,14 +123,14 @@ jobs:
             fi
 
             # 4.3: ensure doesn't contains ASF CATEGORY X License dependencies in LICENSE and NOTICE files
-            COUNT=$(grep -E $CATEGORY_X LICENSE NOTICE | wc -l)
+            COUNT=$(grep -E "$CATEGORY_X" LICENSE NOTICE | wc -l)
             if [[ $COUNT -ne 0 ]]; then
               grep -E "$CATEGORY_X" LICENSE NOTICE
               echo "The package $i shouldn't include invalid ASF category X dependencies, but get $COUNT" && exit 1
             fi
           
             # 4.4: ensure doesn't contains ASF CATEGORY B License dependencies in LICENSE and NOTICE files
-            COUNT=$(grep -E $CATEGORY_B LICENSE NOTICE | wc -l)
+            COUNT=$(grep -E "$CATEGORY_B" LICENSE NOTICE | wc -l)
             if [[ $COUNT -ne 0 ]]; then
               grep -E "$CATEGORY_B" LICENSE NOTICE
               echo "The package $i shouldn't include invalid ASF category B dependencies, but get $COUNT" && exit 1
@@ -267,7 +267,7 @@ jobs:
             fi
 
             # 7.3: ensure doesn't contains ASF CATEGORY X License dependencies in LICENSE/NOTICE and licenses/* files
-            COUNT=$(grep -r -E $CATEGORY_X LICENSE NOTICE licenses | wc -l)
+            COUNT=$(grep -r -E "$CATEGORY_X" LICENSE NOTICE licenses | wc -l)
             if [[ $COUNT -ne 0 ]]; then
               grep -r -E "$CATEGORY_X" LICENSE NOTICE licenses
               echo "The package $i shouldn't include invalid ASF category X dependencies, but get $COUNT" && exit 1

--- a/dist/validate-release.sh
+++ b/dist/validate-release.sh
@@ -105,14 +105,14 @@ for i in *src.tar.gz; do
   fi
 
   # 4.3: ensure doesn't contains ASF CATEGORY X License dependencies in LICENSE and NOTICE files
-  COUNT=$(grep -E $CATEGORY_X LICENSE NOTICE | wc -l)
+  COUNT=$(grep -E "$CATEGORY_X" LICENSE NOTICE | wc -l)
   if [[ $COUNT -ne 0 ]]; then
      grep -E "$CATEGORY_X" LICENSE NOTICE
      echo "The package $i shouldn't include invalid ASF category X dependencies, but get $COUNT" && exit 1
   fi
 
   # 4.4: ensure doesn't contains ASF CATEGORY B License dependencies in LICENSE and NOTICE files
-  COUNT=$(grep -E $CATEGORY_B LICENSE NOTICE | wc -l)
+  COUNT=$(grep -E "$CATEGORY_B" LICENSE NOTICE | wc -l)
   if [[ $COUNT -ne 0 ]]; then
      grep -E "$CATEGORY_B" LICENSE NOTICE
      echo "The package $i shouldn't include invalid ASF category B dependencies, but get $COUNT" && exit 1
@@ -211,8 +211,8 @@ bin/stop-hugegraph.sh || exit
 popd || exit
 
 # clear source packages
-rm -rf ./*src*
-ls -lh
+#rm -rf ./*src*
+#ls -lh
 
 ####################################
 # Step 7: Validate Binary Packages #
@@ -252,7 +252,7 @@ for i in *.tar.gz; do
   fi
 
   # 7.3: ensure doesn't contains ASF CATEGORY X License dependencies in LICENSE/NOTICE and licenses/* files
-  COUNT=$(grep -r -E $CATEGORY_X LICENSE NOTICE licenses | wc -l)
+  COUNT=$(grep -r -E "$CATEGORY_X" LICENSE NOTICE licenses | wc -l)
   if [[ $COUNT -ne 0 ]]; then
     grep -r -E "$CATEGORY_X" LICENSE NOTICE licenses
     echo "The package $i shouldn't include invalid ASF category X dependencies, but get $COUNT" && exit 1


### PR DESCRIPTION
As title, if double quotes are not added, an error will occur during grep:

```text
grep: License|BSD-4-Clause|\bBCL\b|JSR-275|Amazon: No such file or directory
grep: Software: No such file or directory
grep: License|\bRSAL\b|\bQPL\b|\bSSPL|\bCPOL|\bNPL1|Creative: No such file or directory
grep: Commons: No such file or directory
grep: Non-Commercial: No such file or directory
```
