### PR TITLE
doc(hubble): enhance hubble usage doc/command

### DIFF
--- a/content/cn/docs/quickstart/hugegraph-hubble.md
+++ b/content/cn/docs/quickstart/hugegraph-hubble.md
@@ -135,7 +135,7 @@ git clone https://github.com/apache/hugegraph-toolchain.git
 编译`hubble`, 它依赖 loader 和 client, 编译时需提前构建这些依赖 (后续可跳)
 
 ```shell
-cd incubator-hugegraph-toolchain
+cd hugegraph-toolchain
 sudo pip install -r hugegraph-hubble/hubble-dist/assembly/travis/requirements.txt
 mvn install -pl hugegraph-client,hugegraph-loader -am -Dmaven.javadoc.skip=true -DskipTests -ntp
 cd hugegraph-hubble

--- a/content/cn/docs/quickstart/hugegraph-hubble.md
+++ b/content/cn/docs/quickstart/hugegraph-hubble.md
@@ -105,26 +105,7 @@ starting HugeGraphHubble ..............timed out with http status 502
 
 #### 2.3 源码编译
 
-**注意：** 编译 hubble 需要用户本地环境有安装 `Nodejs V16.x` 与 `yarn` 环境
-
-```bash
-apt install curl build-essential
-curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.1/install.sh | bash
-source ~/.bashrc
-nvm install 16
-```
-
-然后确认安装版本是否为 `16.x` (请注意过高的 Node 版本会产生冲突)
-
-```bash
-node -v
-```
-
-使用下列命令安装 `yarn`
-
-```bash
-npm install -g yarn
-```
+**注意：** 目前已在 `hugegraph-hubble/hubble-be/pom.xml` 中引入插件 `frontend-maven-plugin`，编译 hubble 时不需要用户本地环境提前安装 `Nodejs V16.x` 与 `yarn` 环境，可直接按下述步骤执行
 
 下载 toolchain 源码包
 

--- a/content/en/docs/quickstart/hugegraph-hubble.md
+++ b/content/en/docs/quickstart/hugegraph-hubble.md
@@ -105,7 +105,7 @@ Then use a web browser to access `ip:8088` and you can see the `Hubble` page. Yo
 
 #### 2.3 Source code compilation
 
-**Note**: The plugin 'frontend-maven-plugin' has been added to 'hugegraph-hubble/hubble-be/pom.xml'. To compile hubble, you do not need to install 'Nodejs V16.x' and 'yarn' environment in your local environment in advance. You can directly execute the following steps.
+**Note**: The plugin `frontend-maven-plugin` has been added to `hugegraph-hubble/hubble-be/pom.xml`. To compile hubble, you do not need to install `Nodejs V16.x` and `yarn` environment in your local environment in advance. You can directly execute the following steps.
 
 Download the toolchain source code.
 

--- a/content/en/docs/quickstart/hugegraph-hubble.md
+++ b/content/en/docs/quickstart/hugegraph-hubble.md
@@ -135,7 +135,7 @@ git clone https://github.com/apache/hugegraph-toolchain.git
 Compile `hubble`. It depends on the loader and client, so you need to build these dependencies in advance during the compilation process (you can skip this step later).
 
 ```shell
-cd incubator-hugegraph-toolchain
+cd hugegraph-toolchain
 sudo pip install -r hugegraph-hubble/hubble-dist/assembly/travis/requirements.txt
 mvn install -pl hugegraph-client,hugegraph-loader -am -Dmaven.javadoc.skip=true -DskipTests -ntp
 cd hugegraph-hubble

--- a/content/en/docs/quickstart/hugegraph-hubble.md
+++ b/content/en/docs/quickstart/hugegraph-hubble.md
@@ -105,26 +105,7 @@ Then use a web browser to access `ip:8088` and you can see the `Hubble` page. Yo
 
 #### 2.3 Source code compilation
 
-**Note**: Compiling Hubble requires the user's local environment to have Node.js V16.x and yarn installed.
-
-```bash
-apt install curl build-essential
-curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.1/install.sh | bash
-source ~/.bashrc
-nvm install 16
-```
-
-Then, verify that the installed Node.js version is 16.x (please note that higher Node version may cause conflicts).
-
-```bash
-node -v
-```
-
-install `yarn` by the command below:
-
-```bash
-npm install -g yarn
-```
+**Note**: The plugin 'frontend-maven-plugin' has been added to 'hugegraph-hubble/hubble-be/pom.xml'. To compile hubble, you do not need to install 'Nodejs V16.x' and 'yarn' environment in your local environment in advance. You can directly execute the following steps.
 
 Download the toolchain source code.
 


### PR DESCRIPTION
<!-- 
  Thank you very much for contributing to Apache HugeGraph, we are happy that you want to help us improve it!

  Here are some tips for you:
    1. If this is your first time, please read the [contributing guidelines](https://github.com/apache/hugegraph/blob/master/CONTRIBUTING.md)

    2. If a PR fix/close an issue, type the message "close xxx" (xxx is the link of related 
issue) in the content, GitHub will auto link it (Required)

    3. Name the PR title in "Google Commit Format", start with "feat | fix | perf | refactor | doc | chore", 
      such like: "feat(core): support the PageRank algorithm" or "fix: wrong break in the compute loop" (module is optional)
      skip it if you are unsure about which is the best component.

    4. One PR address one issue, better not to mix up multiple issues.

    5. Put an `x` in the `[ ]` to mark the item as CHECKED. `[x]` (or click it directly after 
published)
-->

## Purpose of the PR

-  Currently, the git download target directory and the cd target file directory are inconsistent, so we are trying to unify them

<!--
Please explain more context in this section, clarify why the changes are needed. 
e.g:
- If you propose a new API, clarify the use case for a new API.
- If you fix a bug, you can clarify why it is a bug, and should be associated with an issue.
-->

## Main Changes

<!-- Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. These change logs are helpful for better ant faster reviews.)

For example:

- If you introduce a new feature, please show detailed design here or add the link of design documentation.
- If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
- If there is a discussion in the mailing list, please add the link. -->
- Change "cd incubator-hugegraph-toolchain" in  en doc  Section 2.3 to "cd hugegraph-toolchain"
- Change "cd incubator-hugegraph-toolchain" in  cn doc Section 2.3 to "cd hugegraph-toolchain"
- In the source compilation section, remove the node and yarn installation flow (en doc & cn doc)
    - The plugin `frontend-maven-plugin` has been added to `hugegraph-hubble/hubble-be/pom.xml`. To compile hubble, we do not need to install `Nodejs V16.x` and `yarn` environment in your local environment in advance. 

