### PR TITLE
Link to HugeGraph-specific security page from footer

### DIFF
--- a/themes/docsy/layouts/partials/footer.html
+++ b/themes/docsy/layouts/partials/footer.html
@@ -12,12 +12,12 @@
               </div>
             </a>
             <ul class="footer-link">
-              <li><a class="white" href="http://www.apache.org">Foundation</a></li>
-              <li><a class="white" href="http://www.apache.org/licenses/">License</a></li>
-              <li><a class="white" href="https://www.apache.org/security/">Security</a></li>
-              <li><a class="white" href="http://www.apache.org/events/current-event">Events</a></li>
-              <li><a class="white" href="http://www.apache.org/foundation/sponsorship.html">Sponsorship</a></li>
-              <li><a class="white" href="http://www.apache.org/foundation/thanks.html">Thanks</a></li>
+              <li><a class="white" href="https://www.apache.org">Foundation</a></li>
+              <li><a class="white" href="https://www.apache.org/licenses/">License</a></li>
+              <li><a class="white" href="https://hugegraph.apache.org/docs/guides/security">Security</a></li>
+              <li><a class="white" href="https://www.apache.org/events/current-event">Events</a></li>
+              <li><a class="white" href="https://www.apache.org/foundation/sponsorship.html">Sponsorship</a></li>
+              <li><a class="white" href="https://www.apache.org/foundation/thanks.html">Thanks</a></li>
               <li><a class="white" href="https://privacy.apache.org/policies/privacy-policy-public.html" target="_blank">Privacy</a></li>
             </ul>
           </div>


### PR DESCRIPTION
## Purpose of the PR

Make the project-specific security page more prominent by linking to it from the website footer.

(also changed some links to https)

