### PR TITLE
docs: add Docker deployment instructions for HugeGraph-AI

### DIFF
--- a/content/cn/docs/quickstart/hugegraph-ai.md
+++ b/content/cn/docs/quickstart/hugegraph-ai.md
@@ -16,21 +16,52 @@ hugegraph-ai 旨在探索 HugeGraph 与人工智能（AI）的融合，包括与
 
 1. 启动HugeGraph数据库，可以通过 [Docker](https://hub.docker.com/r/hugegraph/hugegraph)/[Binary Package](https://hugegraph.apache.org/docs/download/download/) 运行它。  
     请参阅详细[文档](https://hugegraph.apache.org/docs/quickstart/hugegraph-server/#31-use-docker-container-convenient-for-testdev)以获取更多指导
-2. 克隆项目
+
+2. **Docker部署**  
+   如果您希望使用Docker来部署HugeGraph-AI，请按照以下步骤操作：
+   - 确保您已安装Docker。
+   - 在项目根目录下，使用以下命令拉取远端Docker容器镜像，我们提供了两种容器镜像：
+     - **镜像1**：[hugegraph/rag](https://hub.docker.com/r/hugegraph/rag/tags)  
+       该镜像用于构建和运行HugeGraph-AI的RAG（检索增强生成）功能，适合需要快速部署和使用的用户。
+     - **镜像2**：[hugegraph/rag-bin](https://hub.docker.com/r/hugegraph/rag-bin/tags)  
+       该镜像提供了二进制版本的HugeGraph-AI，适合需要更稳定和高效性能的用户。
+   - 使用以下命令拉取远端Docker容器镜像：
+     ```bash
+     docker pull hugegraph/rag:latest # 拉取镜像1
+     docker pull hugegraph/rag-bin:latest # 拉取镜像2
+     ```
+   - 使用以下指令启动Docker容器：
+     ```bash
+     docker run -it --name rag -p 8001:8001 hugegraph/rag bash
+     docker run -it --name rag -p 8001:8001 hugegraph/rag-bin bash
+     ```
+   - 启动 **Graph RAG** 的 gradio 交互 demo，可以使用以下命令运行：
+     ```bash
+     python ./src/hugegraph_llm/demo/rag_demo/app.py # 在镜像一创建的容器中启动demo
+     ```
+     ```bash
+     ./app.dist/app.bin # 在镜像二创建的容器中启动demo
+     ```
+   - 启动后，您可以通过访问 http://localhost:8001 来使用HugeGraph-AI的交互式界面。
+
+3. 克隆项目
     ```bash
     git clone https://github.com/apache/incubator-hugegraph-ai.git
     ```
-3. 安装 [hugegraph-python-client](../hugegraph-python-client) 和 [hugegraph_llm](src/hugegraph_llm)
+
+4. 安装 [hugegraph-python-client](../hugegraph-python-client) 和 [hugegraph_llm](src/hugegraph_llm)
     ```bash
     cd ./incubator-hugegraph-ai # better to use virtualenv (source venv/bin/activate) 
     pip install ./hugegraph-python-client
     pip install -r ./hugegraph-llm/requirements.txt
     ```
-4. 进入项目目录
+
+5. 进入项目目录
     ```bash
     cd ./hugegraph-llm/src
     ```
-5. 启动 **Graph RAG** 的 gradio 交互 demo，可以使用以下命令运行，启动后打开 http://127.0.0.1:8001
+
+6. 启动 **Graph RAG** 的 gradio 交互 demo，可以使用以下命令运行，启动后打开 http://127.0.0.1:8001
     ```bash
     python3 -m hugegraph_llm.demo.rag_demo.app
     ```
@@ -38,18 +69,22 @@ hugegraph-ai 旨在探索 HugeGraph 与人工智能（AI）的融合，包括与
     ```bash
     python3 -m hugegraph_llm.demo.rag_demo.app --host 127.0.0.1 --port 18001
     ```
-6. 启动 **Text2Gremlin** 的 gradio 交互演示，可以使用以下命令运行，启动后打开 http://127.0.0.1:8002 ，您还可以按上述方式更改默认主机 `0.0.0.0` 和端口 `8002` 。(🚧ing)
+
+7. 启动 **Text2Gremlin** 的 gradio 交互演示，可以使用以下命令运行，启动后打开 http://127.0.0.1:8002 ，您还可以按上述方式更改默认主机 `0.0.0.0` 和端口 `8002` 。(🚧ing)
     ```bash
     python3 -m hugegraph_llm.demo.gremlin_generate_web_demo
    ```
-7. 在运行演示程序后，配置文件文件将被删除。`.env ` 将自动生成在 `hugegraph-llm/.env` 路径下。此外，还有一个与 prompt 相关的配置文件 `config_prompt.yaml` 。也会在`hugegraph-llm/src/hugegraph_llm/resources/demo/config_prompt.yaml`路径下生成。
+
+8. 在运行演示程序后，配置文件文件将被删除。`.env ` 将自动生成在 `hugegraph-llm/.env` 路径下。此外，还有一个与 prompt 相关的配置文件 `config_prompt.yaml` 。也会在`hugegraph-llm/src/hugegraph_llm/resources/demo/config_prompt.yaml`路径下生成。
     您可以在页面上修改内容，触发相应功能后会自动保存到配置文件中。你也可以直接修改文件而无需重启应用程序；只需刷新页面即可加载最新的更改。
     （可选）要重新生成配置文件，您可以将 `config.generate` 与 `-u` 或 `--update` 一起使用。
     ```bash
     python3 -m hugegraph_llm.config.generate --update
     ```
-8. （**可选**）您可以使用 [hugegraph-hubble](https://hugegraph.apache.org/docs/quickstart/hugegraph-hubble/#21-use-docker-convenient-for-testdev) 来访问图形数据，可以通过 [Docker/Docker-Compose](https://hub.docker.com/r/hugegraph/hubble) 运行它以获得指导。 （Hubble 是一个图形分析仪表板，包括数据加载/模式管理/图形遍历/显示）。
-9. （__可选__）离线下载 NLTK 停用词
+
+9. （**可选**）您可以使用 [hugegraph-hubble](https://hugegraph.apache.org/docs/quickstart/hugegraph-hubble/#21-use-docker-convenient-for-testdev) 来访问图形数据，可以通过 [Docker/Docker-Compose](https://hub.docker.com/r/hugegraph/hubble) 运行它以获得指导。 （Hubble 是一个图形分析仪表板，包括数据加载/模式管理/图形遍历/显示）。
+
+10. （__可选__）离线下载 NLTK 停用词
     ```bash
     python ./hugegraph_llm/operators/common_op/nltk_helper.py
     ```
@@ -65,7 +100,7 @@ hugegraph-ai 旨在探索 HugeGraph 与人工智能（AI）的融合，包括与
   - file: 上传文件：<u>TXT</u> 或 <u>.docx</u>（可同时选择多个文件）
 - [Schema](https://hugegraph.apache.org/docs/clients/restful-api/schema/):（接受**2种类型**）
   - 用户定义模式( JSON 格式，遵循[模板](https://github.com/apache/incubator-hugegraph-ai/blob/aff3bbe25fa91c3414947a196131be812c20ef11/hugegraph-llm/src/hugegraph_llm/config/config_data.py#L125)来修改它)
-  - 指定 HugeGraph 图实例的名称，它将自动从中获取模式(如 **“hugegraph”**)
+  - 指定 HugeGraph 图实例的名称，它将自动从中获取模式(如 **"hugegraph"**)
 - Graph extract head: 用户自定义的图提取提示
 - 如果已经存在图数据，你应该点击 "**Rebuild vid Index**" 来更新索引
 

--- a/content/en/docs/quickstart/hugegraph-ai.md
+++ b/content/en/docs/quickstart/hugegraph-ai.md
@@ -9,92 +9,110 @@ hugegraph-ai aims to explore the integration of HugeGraph and artificial intelli
 with large models, integration with graph machine learning components, etc., to provide comprehensive support for developers to use HugeGraph's AI capabilities in projects.
 
 ## 2 Environment Requirements
-- python 3.9+ 
-- hugegraph-server 1.2+
+- Python 3.9+ (better to use `3.10`)  
+- HugeGraph Server 1.3+
 
 ## 3 Preparation
 
 1. Start the HugeGraph database, you can run it via [Docker](https://hub.docker.com/r/hugegraph/hugegraph)/[Binary Package](https://hugegraph.apache.org/docs/download/download/).  
     Refer to detailed [doc](https://hugegraph.apache.org/docs/quickstart/hugegraph-server/#31-use-docker-container-convenient-for-testdev) for more guidance
 
-2. Clone this project
+2. **Docker Deployment**  
+   If you wish to deploy HugeGraph-AI using Docker, follow these steps:
+   - Ensure you have Docker installed.
+   - In the project root directory, use the following command to pull the remote Docker container images. We provide two container images:
+     - **Image 1**: [hugegraph/rag](https://hub.docker.com/r/hugegraph/rag/tags)  
+       This image is used to build and run the RAG (Retrieval-Augmented Generation) functionality of HugeGraph-AI, suitable for users who need quick deployment and usage.
+     - **Image 2**: [hugegraph/rag-bin](https://hub.docker.com/r/hugegraph/rag-bin/tags)  
+       This image provides a binary version of HugeGraph-AI, suitable for users who require more stable and efficient performance.
+   - Use the following command to pull the remote Docker container images:
+     ```bash
+     docker pull hugegraph/rag:latest # Pull Image 1
+     docker pull hugegraph/rag-bin:latest # Pull Image 2
+     ```
+   - Use the following command to start the Docker container:
+     ```bash
+     docker run -it --name rag -p 8001:8001 hugegraph/rag bash
+     docker run -it --name rag -p 8001:8001 hugegraph/rag-bin bash
+     ```
+   - Start the **Graph RAG** gradio interactive demo using the following command:
+     ```bash
+     python ./src/hugegraph_llm/demo/rag_demo/app.py # Start demo in the container created by Image 1
+     ```
+     ```bash
+     ./app.dist/app.bin # Start demo in the container created by Image 2
+     ```
+   - After starting, you can access the HugeGraph-AI interactive interface at http://localhost:8001.
+
+3. Clone the project
     ```bash
     git clone https://github.com/apache/incubator-hugegraph-ai.git
     ```
-    
-3. Install [hugegraph-python-client](../hugegraph-python-client) and [hugegraph_llm](src/hugegraph_llm)
+
+4. Install [hugegraph-python-client](../hugegraph-python-client) and [hugegraph_llm](src/hugegraph_llm)
     ```bash
     cd ./incubator-hugegraph-ai # better to use virtualenv (source venv/bin/activate) 
     pip install ./hugegraph-python-client
     pip install -r ./hugegraph-llm/requirements.txt
     ```
-    
-4. Enter the project directory
+
+5. Enter the project directory
     ```bash
     cd ./hugegraph-llm/src
     ```
 
-5. Start the gradio interactive demo of **Graph RAG**, you can run with the following command, and open http://127.0.0.1:8001 after starting
+6. Start the **Graph RAG** gradio interactive demo using the following command, which will open http://127.0.0.1:8001
     ```bash
     python3 -m hugegraph_llm.demo.rag_demo.app
     ```
-    The default host is `0.0.0.0` and the port is `8001`. You can change them by passing command line arguments`--host` and `--port`.  
+    The default host is `0.0.0.0`, and the port is `8001`. You can change them by passing the command-line arguments `--host` and `--port`.
     ```bash
     python3 -m hugegraph_llm.demo.rag_demo.app --host 127.0.0.1 --port 18001
     ```
 
-6. Or start the gradio interactive demo of **Text2Gremlin**, you can run with the following command, and open http://127.0.0.1:8002 after starting. You can also change the default host `0.0.0.0` and port `8002` as above. (🚧ing)
+7. Start the **Text2Gremlin** gradio interactive demo using the following command, which will open http://127.0.0.1:8002. You can also change the default host `0.0.0.0` and port `8002` as described above. (🚧ing)
     ```bash
     python3 -m hugegraph_llm.demo.gremlin_generate_web_demo
    ```
 
-7. After running the web demo, the config file `.env` will be automatically generated at the path `hugegraph-llm/.env`.    Additionally, a prompt-related configuration file `config_prompt.yaml` will also be generated at the path `hugegraph-llm/src/hugegraph_llm/resources/demo/config_prompt.yaml`.
-
-    You can modify the content on the web page, and it will be automatically saved to the configuration file after the corresponding feature is triggered.  You can also modify the file directly without restarting the web application; refresh the page to load your latest changes.
-
-    (Optional)To regenerate the config file, you can use `config.generate` with `-u` or `--update`.
+8. After running the demo program, the configuration file will be deleted. The `.env` file will be automatically generated in the `hugegraph-llm/.env` path. Additionally, there is a prompt-related configuration file `config_prompt.yaml` that will also be generated in the `hugegraph-llm/src/hugegraph_llm/resources/demo/config_prompt.yaml` path.
+    You can modify the content on the page, and the changes will be automatically saved to the configuration file after triggering the corresponding function. You can also directly modify the file without restarting the application; just refresh the page to load the latest changes.
+    (Optional) To regenerate the configuration file, you can use `config.generate` with `-u` or `--update`.
     ```bash
     python3 -m hugegraph_llm.config.generate --update
     ```
 
-8. (__Optional__) You could use 
-    [hugegraph-hubble](https://hugegraph.apache.org/docs/quickstart/hugegraph-hubble/#21-use-docker-convenient-for-testdev) 
-    to visit the graph data, could run it via [Docker/Docker-Compose](https://hub.docker.com/r/hugegraph/hubble) 
-    for guidance. (Hubble is a graph-analysis dashboard include data loading/schema management/graph traverser/display).
+9. (**Optional**) You can use [hugegraph-hubble](https://hugegraph.apache.org/docs/quickstart/hugegraph-hubble/#21-use-docker-convenient-for-testdev) to access graph data, which can be run via [Docker/Docker-Compose](https://hub.docker.com/r/hugegraph/hubble) for guidance. (Hubble is a graph analysis dashboard, including data loading, schema management, graph traversal, and display).
 
-9. (__Optional__) offline download NLTK stopwords  
+10. (__Optional__) Download NLTK stopwords offline
     ```bash
     python ./hugegraph_llm/operators/common_op/nltk_helper.py
     ```
-    
 
-## 4 Examples  
-### 4.1 Build a knowledge graph in HugeGraph through LLM
-#### 4.1.1 Build a knowledge graph through the gradio interactive interface
+## 4 Examples 
+### 4.1 Building a Knowledge Graph in HugeGraph via LLM
+#### 4.1.1 Building a Knowledge Graph via the Gradio Interactive Interface
 
-**Parameter description:**  
+**Parameter Description:**  
 
 - Docs:
-  - text: Build rag index from plain text
-  - file: Upload file(s) which should be <u>TXT</u> or <u>.docx</u> (Multiple files can be selected together)
-- [Schema](https://hugegraph.apache.org/docs/clients/restful-api/schema/): (Except **2 types**)
-  - User-defined Schema (JSON format, follow the [template](https://github.com/apache/incubator-hugegraph-ai/blob/aff3bbe25fa91c3414947a196131be812c20ef11/hugegraph-llm/src/hugegraph_llm/config/config_data.py#L125) 
-  to modify it)
-  - Specify the name of the HugeGraph graph instance, it will automatically get the schema from it (like 
-  **"hugegraph"**)
-- Graph extract head: The user-defined prompt of graph extracting
-- If it already exists the graph data, you should click "**Rebuild vid Index**" to update the index
+  - text: Build a RAG index from plain text
+  - file: Upload files: <u>TXT</u> or <u>.docx</u> (you can select multiple files at once)
+- [Schema](https://hugegraph.apache.org/docs/clients/restful-api/schema/): (accepts **2 types**)
+  - User-defined schema (JSON format, follow the [template](https://github.com/apache/incubator-hugegraph-ai/blob/aff3bbe25fa91c3414947a196131be812c20ef11/hugegraph-llm/src/hugegraph_llm/config/config_data.py#L125) to modify it)
+  - Specify the name of the HugeGraph instance, which will automatically retrieve the schema from it (e.g., **"hugegraph"**)
+- Graph extract head: User-defined graph extraction prompt
+- If graph data already exists, you should click "**Rebuild vid Index**" to update the index
 
 ![gradio-config](/docs/images/gradio-kg.png)
 
-#### 4.1.2 Build a knowledge graph through code
+##### 4.1.2 Building a Knowledge Graph via Code
 
-The `KgBuilder` class is used to construct a knowledge graph. Here is a brief usage guide:
+The `KgBuilder` class is used to build a knowledge graph. Here is the usage process:
 
-1. **Initialization**: The `KgBuilder` class is initialized with an instance of a language model. 
-This can be obtained from the `LLMs` class.  
-    Initialize the LLMs instance, get the LLM, and then create a task instance `KgBuilder` for graph construction. `KgBuilder` defines multiple operators, and users can freely combine them according to their needs. (tip: `print_result()` can print the result of each step in the console, without affecting the overall execution logic)
-    ```python
+1. **Initialization**: The `KgBuilder` class is initialized with an instance of a language model. This can be obtained from the `LLMs` class.
+   Initialize the `LLMs` instance, get the `LLM`, and then create a task instance `KgBuilder` for graph construction. `KgBuilder` defines multiple operators, which users can freely combine as needed. (Tip: `print_result()` can print the results of each step in the console without affecting the overall execution logic)
+   ```python
     from hugegraph_llm.models.llms.init_llm import LLMs
     from hugegraph_llm.operators.kg_construction_task import KgBuilder
     
@@ -108,9 +126,9 @@ This can be obtained from the `LLMs` class.
         .commit_to_hugegraph()
         .run()
     )
-    ```
-    ![gradio-config](/docs/images/kg-uml.png)
-2. **Import Schema**: The `import_schema` method is used to import a schema from a source. The source can be a HugeGraph instance, a user-defined schema or an extraction result. The method `print_result` can be chained to print the result.
+   ```
+   ![gradio-config](/docs/images/kg-uml.png)
+2. **Import Schema**: The `import_schema` method is used to import the schema from a source. The source can be a HugeGraph instance, a user-defined schema, or an extraction result. You can link the `print_result` method to print the results.
     ```python
     # Import schema from a HugeGraph instance
     builder.import_schema(from_hugegraph="xxx").print_result()
@@ -119,7 +137,7 @@ This can be obtained from the `LLMs` class.
     # Import schema from user-defined schema
     builder.import_schema(from_user_defined="xxx").print_result()
     ```
-3. **Chunk Split**: The `chunk_split` method is used to split the input text into chunks. The text should be passed as a string argument to the method.
+3. **Chunk Split**: The `chunk_split` method is used to split the input text into chunks. The text should be passed as a string parameter to the method.
     ```python
     # Split the input text into documents
     builder.chunk_split(TEXT, split_type="document").print_result()
@@ -128,7 +146,7 @@ This can be obtained from the `LLMs` class.
     # Split the input text into sentences
     builder.chunk_split(TEXT, split_type="sentence").print_result()
     ```
-4. **Extract Info**: The `extract_info` method is used to extract info from a text. The text should be passed as a string argument to the method.
+4. **Information Extraction**: The `extract_info` method is used to extract information from the text. The text should be passed as a string parameter to the method.
     ```python
     TEXT = "Meet Sarah, a 30-year-old attorney, and her roommate, James, whom she's shared a home with since 2010."
     # extract property graph from the input text
@@ -136,7 +154,7 @@ This can be obtained from the `LLMs` class.
     # extract triples from the input text
     builder.extract_info(extract_type="property_graph").print_result()
     ```
-5. **Commit to HugeGraph**: The `commit_to_hugegraph` method is used to commit the constructed knowledge graph to a HugeGraph instance.
+5. **Commit to HugeGraph**: The `commit_to_hugegraph` method is used to commit the constructed knowledge graph to the HugeGraph instance.
     ```python
     builder.commit_to_hugegraph().print_result()
     ```
@@ -144,31 +162,30 @@ This can be obtained from the `LLMs` class.
     ```python
     builder.run()
     ```
-    The methods of the `KgBuilder` class can be chained together to perform a sequence of operations.
+    The methods of the `KgBuilder` class can be chained together to perform a series of operations.
 
-### 4.2 Retrieval augmented generation (RAG) based on HugeGraph
+#### 4.2 Retrieval-Augmented Generation (RAG) Based on HugeGraph
 
-The `RAGPipeline` class is used to integrate HugeGraph with large language models to provide retrieval-augmented generation capabilities.
-Here is a brief usage guide:
+The `RAGPipeline` class is used to integrate HugeGraph with large language models to provide retrieval-augmented generation functionality. Here is the usage process:
 
-1. **Extract Keyword**: Extract keywords and expand synonyms.
+1. **Extract Keywords**: Extract keywords and expand synonyms.
     ```python
     from hugegraph_llm.operators.graph_rag_task import RAGPipeline
     graph_rag = RAGPipeline()
     graph_rag.extract_keywords(text="Tell me about Al Pacino.").print_result()
     ```
-2. **Match Vid from Keywords**: Match the nodes with the keywords in the graph.
-    ```python
+2. **Match Keywords to Vid**: Match nodes with keywords in the graph.
+	```python
     graph_rag.keywords_to_vid().print_result()
-    ```
-3. **Query Graph for Rag**: Retrieve the corresponding keywords and their multi-degree associated relationships from HugeGraph.
+   ```
+3. **Query Graph for RAG**: Retrieve corresponding keywords and their multi-degree relationships from HugeGraph.
      ```python
      graph_rag.query_graphdb(max_deep=2, max_items=30).print_result()
      ```
-4. **Rerank Searched Result**: Rerank the searched results based on the similarity between the question and the results.
-     ```python
-     graph_rag.merge_dedup_rerank().print_result()
-     ```
+4. **Reorder Search Results**: Reorder the search results based on the similarity between the question and the results.
+    ```python
+    graph_rag.merge_dedup_rerank().print_result()
+    ```
 5. **Synthesize Answer**: Summarize the results and organize the language to answer the question.
     ```python
     graph_rag.synthesize_answer(vector_only_answer=False, graph_only_answer=True).print_result()


### PR DESCRIPTION
## Changes
- Added Docker deployment instructions to `hugegraph-ai.md` documentation
- Added detailed information about two Docker images:
  - hugegraph/rag: For building and running RAG functionality
  - hugegraph/rag-bin: Binary version for more stable performance
- Added complete Docker deployment steps including:
  - Image pulling
  - Container startup
  - Interactive demo running
  - Access methods

## Related Issues
<!-- If there are related issues, please link them here -->

## Testing
- [x] Verified document formatting
- [x] Verified consistency between Chinese and English documentation
- [x] Verified all links are accessible

## Notes
- This is a documentation update only, no code changes
- Maintains consistency with existing documentation style
- Added Docker deployment as a new section in the preparation steps
- Updated step numbering to accommodate the new section

## Additional Context
The Docker deployment instructions provide users with an alternative way to quickly deploy and use HugeGraph-AI, especially for those who prefer containerized environments.

## Difference
![image](https://github.com/user-attachments/assets/76db53c6-3c2d-4fc6-a778-b79e75356bbf)
