### PR TITLE
fix hugegraph-server.md chapter 5.2.2

### DIFF
--- a/content/cn/docs/quickstart/hugegraph-server.md
+++ b/content/cn/docs/quickstart/hugegraph-server.md
@@ -529,16 +529,16 @@ volumes:
 
     ```yaml
     version: '3'
-      services:
-        server:
-          image: hugegraph/hugegraph:1.5.0
-          container_name: server
-          environment:
-            - PRELOAD=true
-          volumes:
-            - /path/to/yourscript:/hugegraph/scripts/example.groovy
-          ports:
-            - 8080:8080
+    services:
+      server:
+        image: hugegraph/hugegraph:1.5.0
+        container_name: server
+        environment:
+          - PRELOAD=true
+        volumes:
+          - /path/to/yourscript:/hugegraph/scripts/example.groovy
+        ports:
+          - 8080:8080
     ```
 
     使用命令 `docker-compose up -d` 启动容器


### PR DESCRIPTION
Chapter 5.2.2 has an indentation issue in the docker-compose.yml code.

## origin code execute result
![image](https://github.com/user-attachments/assets/30228280-2360-489a-89be-562ad6148320)


## Purpose of the PR

- fix hugegraph-server.md chapter 5.2.2 indentation problem

<!-- Better to paste the screenshot diff here, "xxx" is the ID-link of related issue, e.g: #1024 -->
- origin 
![image](https://github.com/user-attachments/assets/c9184adc-efeb-4406-9b50-4e64b3e88ece)

- after fix
![image](https://github.com/user-attachments/assets/0acb7a02-5b7e-428c-87dd-09d291c70a0a)
