### PR TITLE
docs: add DeepWiki badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/apache/hugegraph-doc)
+
 ## Build/Test/Contribute to website
 
 Please visit the [contribution doc](./contribution.md) to get start, include theme/website description & settings~


### PR DESCRIPTION
## Description

This PR adds a DeepWiki badge to the README file, enabling users to easily access interactive, AI-powered documentation for the HugeGraph Doc project.

## Changes
- Added DeepWiki badge at the top of README.md
- Badge links to https://deepwiki.com/apache/hugegraph-doc for up-to-date, interactive documentation

## Benefits
- Provides users with an alternative way to explore documentation through AI assistance
- Enables DeepWiki to automatically index and update project documentation
- Improves documentation accessibility and user experience

## Badge Preview
[![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/apache/hugegraph-doc)